### PR TITLE
Full Model Restoration, Deterministic Loading, and ngclearn v3 Compiler Migration

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,10 +1,10 @@
 class Config:
     SEED = 42
 
-    seq_len =  40
-    n_embed = 512
+    seq_len =  12
+    n_embed = 12
     
-    batch_size = 16
+    batch_size = 8
     vocab_size = 11710# data vocab size + special tokens = 11706 + 4
     n_heads = 2
     n_layers = 4

--- a/config.py
+++ b/config.py
@@ -13,7 +13,7 @@ class Config:
     exp_dir = "exp" 
     pos_learnable = True
     optim_type = "adam"
-    num_iter = 2
+    num_iter = 1
     n_iter= 10
     wub = 0.2
     wlb = -0.2

--- a/config.py
+++ b/config.py
@@ -15,8 +15,8 @@ class Config:
     optim_type = "adam"
     num_iter = 2
     n_iter= 20
-    wub = 0.5
-    wlb = -0.5
+    wub = 0.3
+    wlb = -0.3
     tau_m = 25.
     act_fx = "sigmoid"
     # Tokenizer selection: "BPE" (custom/BPE loader) or "tiktoken"

--- a/config.py
+++ b/config.py
@@ -8,8 +8,8 @@ class Config:
     vocab_size = 11710# data vocab size + special tokens = 11706 + 4
     n_heads = 2
     n_layers = 4
-    dropout_rate = 0.5
-    eta = 0.001
+    dropout_rate = 0.1
+    eta = 0.0001
     exp_dir = "exp" 
     pos_learnable = True
     optim_type = "adam"
@@ -18,7 +18,7 @@ class Config:
     # Approximate Xavier scaling: 1 / sqrt(512) is about 0.04
     wub = 0.05
     wlb = -0.05
-    tau_m = 25.
+    tau_m = 10.
     act_fx = "tanh"
     # Tokenizer selection: "BPE" (custom/BPE loader) or "tiktoken"
     tokenizer = "BPE"

--- a/config.py
+++ b/config.py
@@ -1,24 +1,24 @@
 class Config:
     SEED = 42
-    n_embed = 12
-    seq_len =  12
-    n_embed = 12
-    seq_len =  12
-    batch_size = 5
+
+    seq_len =  40
+    n_embed = 512
+    
+    batch_size = 16
     vocab_size = 11710# data vocab size + special tokens = 11706 + 4
     n_heads = 2
     n_layers = 4
-    dropout_rate = 0.0
-    eta = 0.0000089
+    dropout_rate = 0.5
+    eta = 0.001
     exp_dir = "exp" 
     pos_learnable = True
     optim_type = "adam"
-    num_iter = 1
-    n_iter= 10
-    wub = 0.2
-    wlb = -0.2
-    tau_m = 10.
-    act_fx = "identity"
+    num_iter = 2
+    n_iter= 20
+    wub = 0.5
+    wlb = -0.5
+    tau_m = 25.
+    act_fx = "sigmoid"
     # Tokenizer selection: "BPE" (custom/BPE loader) or "tiktoken"
     tokenizer = "BPE"
     # When tokenizer == "tiktoken", tokenizer_name is used (e.g. "gpt2" or "cl100k_base")

--- a/config.py
+++ b/config.py
@@ -13,12 +13,13 @@ class Config:
     exp_dir = "exp" 
     pos_learnable = True
     optim_type = "adam"
-    num_iter = 2
-    n_iter= 20
-    wub = 0.2
-    wlb = -0.2
+    num_iter = 1
+    n_iter= 10
+    # Approximate Xavier scaling: 1 / sqrt(512) is about 0.04
+    wub = 0.05
+    wlb = -0.05
     tau_m = 25.
-    act_fx = "sigmoid"
+    act_fx = "tanh"
     # Tokenizer selection: "BPE" (custom/BPE loader) or "tiktoken"
     tokenizer = "BPE"
     # When tokenizer == "tiktoken", tokenizer_name is used (e.g. "gpt2" or "cl100k_base")

--- a/config.py
+++ b/config.py
@@ -15,8 +15,8 @@ class Config:
     optim_type = "adam"
     num_iter = 2
     n_iter= 20
-    wub = 0.3
-    wlb = -0.3
+    wub = 0.2
+    wlb = -0.2
     tau_m = 25.
     act_fx = "sigmoid"
     # Tokenizer selection: "BPE" (custom/BPE loader) or "tiktoken"

--- a/config.py
+++ b/config.py
@@ -13,8 +13,8 @@ class Config:
     exp_dir = "exp" 
     pos_learnable = True
     optim_type = "adam"
-    num_iter = 1
-    n_iter= 10
+    num_iter = 3
+    n_iter= 20
     # Approximate Xavier scaling: 1 / sqrt(512) is about 0.04
     wub = 0.05
     wlb = -0.05

--- a/data_preprocess/data_loader.py
+++ b/data_preprocess/data_loader.py
@@ -8,11 +8,15 @@ sys.path.append(str(DIR.parent))
 from config import Config as config
 
 class DataLoader:
-    def __init__(self, data_dir= DIR / "outputs" / "tokenized_data", seq_len=config.seq_len, batch_size=config.batch_size):
+    def __init__(self, data_dir= DIR / "outputs" / "tokenized_data", seq_len=config.seq_len, batch_size=config.batch_size,
+                 train_sample_size=3000,valid_sample_size=2000,test_sample_size=1000):
         self.data_dir = Path(data_dir)
         self.seq_len = seq_len
         self.batch_size = batch_size
         self.pad_token = 0
+        self.train_sample_size = 100
+        self.valid_sample_size = 90
+        self.test_sample_size = 80
 
     def load_and_prepare_data(self):
         """Load tokenized data and prepare for training"""
@@ -20,13 +24,15 @@ class DataLoader:
         valid_tokens = jnp.load(self.data_dir / "valid_tokens.npy")
         test_tokens = jnp.load(self.data_dir / "test_tokens.npy")
 
-        train_loader = self._create_data_loader(train_tokens, shuffle=True)
-        valid_loader = self._create_data_loader(valid_tokens, shuffle=False)
-        test_loader = self._create_data_loader(test_tokens, shuffle=False)
+        train_loader = self._create_data_loader(train_tokens, shuffle=True, max_sequences=self.train_sample_size)
+        valid_loader = self._create_data_loader(valid_tokens, shuffle=False, max_sequences=self.valid_sample_size)
+        test_loader = self._create_data_loader(test_tokens, shuffle=False, max_sequences=self.test_sample_size)
+
+        
 
         return train_loader, valid_loader, test_loader
 
-    def _create_data_loader(self, tokens, shuffle):
+    def _create_data_loader(self, tokens, shuffle,max_sequences=None):
         """Create sequences and return NGC DataLoader"""
         window_size = self.seq_len + 1 
         num_sequences = (len(tokens) - window_size + 1) // 1  
@@ -38,11 +44,17 @@ class DataLoader:
             ])
             sequences = padded_tokens.reshape(1, -1)  
         else:
-            sequences = []
-            for i in range(num_sequences):
-                window = tokens[i:i + window_size]
-                sequences.append(window)
-            sequences = jnp.stack(sequences)  
+            # sequences = []
+            # for i in range(num_sequences):
+            #     window = tokens[i:i + window_size]
+            #     sequences.append(window)
+            # sequences = jnp.stack(sequences)  
+             # Create sliding window sequences
+            indices = jnp.arange(num_sequences)[:, None] + jnp.arange(window_size)
+            sequences = tokens[indices]  # Shape: (num_available_sequences, window_size)
+        # Apply sampling: take first `max_sequences` if specified
+        if max_sequences is not None and sequences.shape[0] > max_sequences:
+            sequences = sequences[:max_sequences]
         
         inputs = sequences[:, :-1]    
         targets = sequences[:, 1:]    

--- a/eval.py
+++ b/eval.py
@@ -84,17 +84,13 @@ if __name__ == "__main__":
         eta=config.eta,
         dropout_rate=config.dropout_rate,
         exp_dir="exp",
-        model_name="ngc transformer",
-        loadDir=None,
+        model_name="ngc_transformer",
+        loadDir="exp",  
         pos_learnable=config.pos_learnable,
         optim_type=config.optim_type,
         wub=config.wub,
         wlb=config.wlb,
     )
-
-    model_dir = "exp/ngc transformer"
-    load_weights_into_model(model, model_dir)
-
     data_loader = DataLoader(seq_len=config.seq_len, batch_size=config.batch_size)
     _, _, test_loader = data_loader.load_and_prepare_data()
 

--- a/fine_tune.py
+++ b/fine_tune.py
@@ -1,0 +1,154 @@
+import alogos as al
+import jax.numpy as jnp
+from jax import random, clear_caches
+import numpy as np
+import sys
+import gc
+import os
+import traceback
+from config import Config as config
+
+
+os.environ["PYTHONUNBUFFERED"] = "1"
+os.environ["XLA_PYTHON_CLIENT_PREALLOCATE"] = "false"
+
+try:
+    from model import NGCTransformer
+    from ngclearn.utils.metric_utils import measure_CatNLL
+    from data_preprocess.data_loader import DataLoader
+    from eval import eval_model
+except ImportError as e:
+    print(f"Import Error: {e}. Check project path.")
+    sys.exit(1)
+
+
+LOG_FILE = "search_progress.log"
+
+def log_message(message, end="\n"):
+    print(message, end=end, flush=True)
+    with open(LOG_FILE, "a") as f:
+        f.write(message + end)
+
+with open(LOG_FILE, "w") as f:
+    f.write("=== New Search Session ===\n")
+
+FIXED_BS = config.batch_size
+FIXED_BLOCK = config.seq_len
+FIXED_VOCAB = config.vocab_size
+
+bnf_text = """
+<hparams> ::= <e64> "," <layers> "," <eta> "," <act> "," <bounds> "," <bs>
+            | <e128> "," <layers> "," <eta> "," <act> "," <bounds> "," <bs>
+            | <e256> "," <layers> "," <eta> "," <act> "," <bounds> "," <bs>
+
+<e64>    ::= "n_embed=64,n_heads=4" | "n_embed=64,n_heads=8"
+<e128>   ::= "n_embed=128,n_heads=4" | "n_embed=128,n_heads=8"
+<e256>   ::= "n_embed=256,n_heads=4" | "n_embed=256,n_heads=8"
+
+<layers> ::= "n_layers=2" | "n_layers=4" | "n_layers=6"
+<eta>    ::= "eta=0.01" | "eta=0.005" | "eta=0.001"
+<act>    ::= "act_fx=identity" | "act_fx=lrelu" | "act_fx=tanh"
+<bounds> ::= <wlb> "," <wub>
+<wlb>   ::= "wlb=-0.10" | "wlb=-0.05" | "wlb=-0.01"
+<wub>   ::= "wub=0.01" | "wub=0.05" | "wub=0.10"
+<bs>    ::= "batch_size=4" | "batch_size=8" | "batch_size=16"
+"""
+
+
+def objective_function(phenotype_string):
+    clean_string = phenotype_string.replace('"', '').replace(' ', '')
+    log_message(f"\n[Testing Config]: {clean_string}")
+    
+    model = None
+    val_ce = None
+    status = "SUCCESS"
+    
+    try:
+        params = {p.split('=')[0]: p.split('=')[1] for p in clean_string.split(',')}
+        dkey = random.PRNGKey(42)
+        bs = int(params.get('batch_size', FIXED_BS))
+        data_loader = DataLoader(seq_len=FIXED_BLOCK, batch_size=bs)
+        train_loader, valid_loader, _ = data_loader.load_and_prepare_data()
+        
+        model = NGCTransformer(
+            dkey,  
+            batch_size=bs, 
+            seq_len=FIXED_BLOCK, 
+            n_embed=int(params['n_embed']),
+            vocab_size=FIXED_VOCAB, 
+            n_layers=int(params['n_layers']), 
+            n_heads=int(params['n_heads']),
+            T=config.n_iter, 
+            dt=1.0, 
+            tau_m=config.tau_m, 
+            act_fx=params['act_fx'], 
+            eta=float(params['eta']),
+            dropout_rate=float(config.dropout_rate), 
+            pos_learnable=config.pos_learnable,
+            optim_type=config.optim_type,
+            wub=float(params.get('wub', config.wub)), 
+            wlb=float(params.get('wlb', config.wlb)), 
+            exp_dir="exp",
+            loadDir=None,
+            model_name="ngc_transformer"
+        )
+
+        log_message(f"    {'Iter':<5} | {'Batch CE':<12} | {'Batch PPL':<12}")
+        log_message(f"    {'-' * 35}")
+
+        train_iter = iter(train_loader)
+        for i in range(10):
+            log_message(f"    {i+1:<5} | ", end="")
+            
+            try:
+                batch = next(train_iter)
+            except StopIteration:
+                train_iter = iter(train_loader)
+                batch = next(train_iter)
+
+            inputs = batch[0][1][:bs, :FIXED_BLOCK]
+            targets = batch[1][1][:bs, :FIXED_BLOCK]
+            targets_flat = jnp.eye(FIXED_VOCAB)[targets].reshape(-1, FIXED_VOCAB)
+            
+            # --- The Learning Step ---
+            preds = model.process(obs=inputs, lab=targets_flat, adapt_synapses=True)
+            
+            # --- FIX FOR TUPLE ERROR ---
+            # If preds is a tuple (common in some NGCLearn versions), take the first element (the actual mu)
+            if isinstance(preds, tuple):
+                preds = preds[0]
+            
+            it_ce = float(measure_CatNLL(preds, targets_flat))
+            it_ppl = float(np.exp(it_ce))
+            
+            log_message(f"{it_ce:<12.4f} | {it_ppl:<12.2f}")
+
+        val_ce, _ = eval_model(model, valid_loader, FIXED_VOCAB)
+        return float(val_ce)
+
+    except Exception as e:
+        # This will print the full error path so you can see where the 'tuple' comes from
+        error_trace = traceback.format_exc()
+        log_message(f"\n    [!] ERROR: {e}")
+        log_message(f"    DEBUG TRACE:\n{error_trace}")
+        return 5000.0
+
+    finally:
+        if model is not None:
+            del model
+        clear_caches()
+        gc.collect()
+
+def main():
+    grammar = al.Grammar(bnf_text=bnf_text)
+    ea = al.EvolutionaryAlgorithm(grammar, objective_function, 'min', population_size=10, max_generations=5)
+    
+    log_message("\n" + "="*45)
+    log_message("STARTING SEARCH (FIXING TUPLE ERROR)")
+    log_message("="*45)
+    
+    best_ind = ea.run()
+    log_message(f"\nBEST CONFIG: {best_ind.phenotype}")
+
+if __name__ == "__main__":
+    main()

--- a/layers/attention.py
+++ b/layers/attention.py
@@ -1,5 +1,5 @@
 from ngclearn.components import GaussianErrorCell as ErrorCell, RateCell, HebbianSynapse, StaticSynapse
-import ngclearn.utils.weight_distribution as dist
+from ngclearn.utils.distribution_generator import DistributionGenerator as dist
 from jax import numpy as jnp, random, jit
 import jax
 from config import Config as config
@@ -38,17 +38,17 @@ class Attention:
         self.W_q = HebbianSynapse(f"{prefix}W_q", shape=(n_embed, n_embed), batch_size=batch_size * seq_len, eta=eta,
                                 weight_init=dist.uniform(amin=wlb, amax=wub),
                                 bias_init=dist.constant(value=0.), w_bound=0., 
-                                optim_type=optim_type, sign_value= -1.0, key=subkeys[0])
+                                optim_type=optim_type, sign_value= 1.0, key=subkeys[0])
         
         self.W_k = HebbianSynapse(f"{prefix}W_k", shape=(n_embed, n_embed), batch_size=batch_size * seq_len, eta=eta,
                                 weight_init=dist.uniform(amin=wlb, amax=wub),
                                 bias_init=dist.constant(value=0.), w_bound=0., 
-                                optim_type=optim_type, sign_value= -1.0, key=subkeys[1])
+                                optim_type=optim_type, sign_value= 1.0, key=subkeys[1])
         
         self.W_v = HebbianSynapse(f"{prefix}W_v", shape=(n_embed, n_embed), batch_size=batch_size * seq_len, eta=eta,
                                 weight_init=dist.uniform(amin=wlb, amax=wub),
                                 bias_init=dist.constant(value=0.), w_bound=0., 
-                                optim_type=optim_type, sign_value= -1.0, key=subkeys[2])
+                                optim_type=optim_type, sign_value= 1.0, key=subkeys[2])
        
         self.attn_block = AttentionBlock(f"{prefix}attn_block", n_heads=n_heads, 
                                        n_embed=n_embed, seq_len=seq_len,
@@ -58,10 +58,10 @@ class Attention:
         self.W_attn_out = HebbianSynapse(f"{prefix}W_attn_out", shape=(n_embed, n_embed), batch_size=batch_size * seq_len, eta=eta,
                             weight_init=dist.uniform(amin=wlb, amax=wub),
                             bias_init=dist.constant(value=0.), w_bound=0., 
-                            optim_type=optim_type, sign_value= -1.0, key=subkeys[3])
+                            optim_type=optim_type, sign_value= 1.0, key=subkeys[3])
         
         self.e_attn = ErrorCell(f"{prefix}e_attn", n_units=n_embed, 
                                   batch_size=batch_size * seq_len) # shape=(seq_len, n_embed, 1),
         
         self.E_attn = StaticSynapse(f"{prefix}E_attn", shape=(n_embed, n_embed),
-                        weight_init=dist.uniform(amin=wlb, amax=wub), bias_init= dist.constant(value=0.), key=subkeys[4])
+                        weight_init=dist.uniform(low=wlb, high=wub),  key=subkeys[4])

--- a/layers/attention.py
+++ b/layers/attention.py
@@ -38,17 +38,17 @@ class Attention:
         self.W_q = HebbianSynapse(f"{prefix}W_q", shape=(n_embed, n_embed), batch_size=batch_size * seq_len, eta=eta,
                                 weight_init=dist.uniform(amin=wlb, amax=wub),
                                 bias_init=dist.constant(value=0.), w_bound=0., 
-                                optim_type=optim_type, sign_value= -1.0, key=subkeys[0],prior=("l1l2", 0.001))
+                                optim_type=optim_type, sign_value= -1.0, key=subkeys[0],prior=("l1l2", (0.001, 0.001)))
         
         self.W_k = HebbianSynapse(f"{prefix}W_k", shape=(n_embed, n_embed), batch_size=batch_size * seq_len, eta=eta,
                                 weight_init=dist.uniform(amin=wlb, amax=wub),
                                 bias_init=dist.constant(value=0.), w_bound=0., 
-                                optim_type=optim_type, sign_value= -1.0, key=subkeys[1],prior=("l1l2", 0.001))
+                                optim_type=optim_type, sign_value= -1.0, key=subkeys[1],prior=("l1l2", (0.001, 0.001)))
         
         self.W_v = HebbianSynapse(f"{prefix}W_v", shape=(n_embed, n_embed), batch_size=batch_size * seq_len, eta=eta,
                                 weight_init=dist.uniform(amin=wlb, amax=wub),
                                 bias_init=dist.constant(value=0.), w_bound=0., 
-                                optim_type=optim_type, sign_value= -1.0, key=subkeys[2],prior=("l1l2", 0.001))
+                                optim_type=optim_type, sign_value= -1.0, key=subkeys[2],prior=("l1l2", (0.001, 0.001)))
        
         self.attn_block = AttentionBlock(f"{prefix}attn_block", n_heads=n_heads, 
                                        n_embed=n_embed, seq_len=seq_len,

--- a/layers/attention.py
+++ b/layers/attention.py
@@ -38,17 +38,17 @@ class Attention:
         self.W_q = HebbianSynapse(f"{prefix}W_q", shape=(n_embed, n_embed), batch_size=batch_size * seq_len, eta=eta,
                                 weight_init=dist.uniform(amin=wlb, amax=wub),
                                 bias_init=dist.constant(value=0.), w_bound=0., 
-                                optim_type=optim_type, sign_value= -1.0, key=subkeys[0])
+                                optim_type=optim_type, sign_value= -1.0, key=subkeys[0],prior=("l1l2", 0.001))
         
         self.W_k = HebbianSynapse(f"{prefix}W_k", shape=(n_embed, n_embed), batch_size=batch_size * seq_len, eta=eta,
                                 weight_init=dist.uniform(amin=wlb, amax=wub),
                                 bias_init=dist.constant(value=0.), w_bound=0., 
-                                optim_type=optim_type, sign_value= -1.0, key=subkeys[1])
+                                optim_type=optim_type, sign_value= -1.0, key=subkeys[1],prior=("l1l2", 0.001))
         
         self.W_v = HebbianSynapse(f"{prefix}W_v", shape=(n_embed, n_embed), batch_size=batch_size * seq_len, eta=eta,
                                 weight_init=dist.uniform(amin=wlb, amax=wub),
                                 bias_init=dist.constant(value=0.), w_bound=0., 
-                                optim_type=optim_type, sign_value= -1.0, key=subkeys[2])
+                                optim_type=optim_type, sign_value= -1.0, key=subkeys[2],prior=("l1l2", 0.001))
        
         self.attn_block = AttentionBlock(f"{prefix}attn_block", n_heads=n_heads, 
                                        n_embed=n_embed, seq_len=seq_len,

--- a/layers/attention.py
+++ b/layers/attention.py
@@ -38,17 +38,17 @@ class Attention:
         self.W_q = HebbianSynapse(f"{prefix}W_q", shape=(n_embed, n_embed), batch_size=batch_size * seq_len, eta=eta,
                                 weight_init=dist.uniform(amin=wlb, amax=wub),
                                 bias_init=dist.constant(value=0.), w_bound=0., 
-                                optim_type=optim_type, sign_value= 1.0, key=subkeys[0])
+                                optim_type=optim_type, sign_value= -1.0, key=subkeys[0])
         
         self.W_k = HebbianSynapse(f"{prefix}W_k", shape=(n_embed, n_embed), batch_size=batch_size * seq_len, eta=eta,
                                 weight_init=dist.uniform(amin=wlb, amax=wub),
                                 bias_init=dist.constant(value=0.), w_bound=0., 
-                                optim_type=optim_type, sign_value= 1.0, key=subkeys[1])
+                                optim_type=optim_type, sign_value= -1.0, key=subkeys[1])
         
         self.W_v = HebbianSynapse(f"{prefix}W_v", shape=(n_embed, n_embed), batch_size=batch_size * seq_len, eta=eta,
                                 weight_init=dist.uniform(amin=wlb, amax=wub),
                                 bias_init=dist.constant(value=0.), w_bound=0., 
-                                optim_type=optim_type, sign_value= 1.0, key=subkeys[2])
+                                optim_type=optim_type, sign_value= -1.0, key=subkeys[2])
        
         self.attn_block = AttentionBlock(f"{prefix}attn_block", n_heads=n_heads, 
                                        n_embed=n_embed, seq_len=seq_len,
@@ -58,7 +58,7 @@ class Attention:
         self.W_attn_out = HebbianSynapse(f"{prefix}W_attn_out", shape=(n_embed, n_embed), batch_size=batch_size * seq_len, eta=eta,
                             weight_init=dist.uniform(amin=wlb, amax=wub),
                             bias_init=dist.constant(value=0.), w_bound=0., 
-                            optim_type=optim_type, sign_value= 1.0, key=subkeys[3])
+                            optim_type=optim_type, sign_value= -1.0, key=subkeys[3])
         
         self.e_attn = ErrorCell(f"{prefix}e_attn", n_units=n_embed, 
                                   batch_size=batch_size * seq_len) # shape=(seq_len, n_embed, 1),

--- a/layers/embedding.py
+++ b/layers/embedding.py
@@ -1,6 +1,6 @@
 
-from ngclearn.components import GaussianErrorCell as ErrorCell, RateCell, HebbianSynapse, StaticSynapse
-import ngclearn.utils.weight_distribution as dist
+from ngclearn.components import GaussianErrorCell as ErrorCell, RateCell
+from ngclearn.utils.distribution_generator import DistributionGenerator as dist
 from config import Config as config
 from utils.embed_utils import EmbeddingSynapse
 from jax import random
@@ -30,11 +30,6 @@ class EMBEDDING:
             
         self.e_embed = ErrorCell("e_embed", n_units=embed_dim, 
                                   batch_size=batch_size * seq_len) # shape=(seq_len, embed_dim, 1),
-    def get_embedding_weights(self):
-        """Get both word and position embeddings"""
-        return {
-                'word_embeddings': self.W_embed.word_weights.value,
-                'position_embeddings': self.W_embed.pos_weights.value
-        }   
+    
             
 

--- a/layers/mlp.py
+++ b/layers/mlp.py
@@ -1,8 +1,7 @@
 import jax
-from ngclearn.utils import JaxProcess
 from jax import numpy as jnp, random, jit
 from ngclearn.components import GaussianErrorCell as ErrorCell, RateCell, HebbianSynapse, StaticSynapse
-import ngclearn.utils.weight_distribution as dist
+from ngclearn.utils.distribution_generator import DistributionGenerator as dist
 from config import Config as config
 
 class MLP:
@@ -22,18 +21,18 @@ class MLP:
         self.z_mlp2 = RateCell(f"{prefix}z_mlp2", n_units= 4* n_embed, tau_m= tau_m, act_fx="gelu", batch_size=batch_size * seq_len)
         
         self.W_mlp1 = HebbianSynapse(f"{prefix}W_mlp1", shape=(n_embed, 4*n_embed), batch_size = batch_size * seq_len, eta=eta, weight_init=dist.uniform(amin=wlb, amax=wub),
-                    bias_init=dist.constant(value=0.), w_bound=0., optim_type=optim_type, sign_value=-1.0, key=subkeys[4])
+                    bias_init=dist.constant(value=0.), w_bound=0., optim_type=optim_type, sign_value=1.0, key=subkeys[4])
         self.W_mlp2 = HebbianSynapse(
                     f"{prefix}W_mlp2", shape=(4*n_embed, n_embed), batch_size= batch_size * seq_len, eta=eta, weight_init=dist.uniform(amin=wlb, amax=wub),
-                    bias_init=dist.constant(value=0.), w_bound=0., optim_type=optim_type, sign_value=-1.0, key=subkeys[5])
+                    bias_init=dist.constant(value=0.), w_bound=0., optim_type=optim_type, sign_value=1.0, key=subkeys[5])
         self.e_mlp = ErrorCell(f"{prefix}e_mlp", n_units=n_embed, 
                                   batch_size=batch_size * seq_len) # shape=(seq_len, n_embed, 1),   
         self.e_mlp1 = ErrorCell(f"{prefix}e_mlp1", n_units= 4* n_embed, 
                                   batch_size=batch_size * seq_len)
         
         
-        self.E_mlp1 = StaticSynapse(f"{prefix}E_mlp1", shape=(4 * n_embed,n_embed), weight_init=dist.uniform(amin=wlb, amax=wub), bias_init= dist.constant(value=0.), key=subkeys[4])
-        self.E_mlp = StaticSynapse(f"{prefix}E_mlp", shape=(n_embed, 4 * n_embed), weight_init=dist.uniform(amin=wlb, amax=wub), bias_init= dist.constant(value=0.), key=subkeys[4])
+        self.E_mlp1 = StaticSynapse(f"{prefix}E_mlp1", shape=(4 * n_embed,n_embed), weight_init=dist.uniform(low=wlb, high=wub), key=subkeys[4])
+        self.E_mlp = StaticSynapse(f"{prefix}E_mlp", shape=(n_embed, 4 * n_embed), weight_init=dist.uniform(low=wlb, high=wub), key=subkeys[4])
     def get_components(self):
         """Return all components for easy access"""
         return {

--- a/layers/mlp.py
+++ b/layers/mlp.py
@@ -21,10 +21,10 @@ class MLP:
         self.z_mlp2 = RateCell(f"{prefix}z_mlp2", n_units= 4* n_embed, tau_m= tau_m, act_fx="gelu", batch_size=batch_size * seq_len)
         
         self.W_mlp1 = HebbianSynapse(f"{prefix}W_mlp1", shape=(n_embed, 4*n_embed), batch_size = batch_size * seq_len, eta=eta, weight_init=dist.uniform(amin=wlb, amax=wub),
-                    bias_init=dist.constant(value=0.), w_bound=0., optim_type=optim_type, sign_value=-1.0, key=subkeys[4])
+                    bias_init=dist.constant(value=0.), w_bound=0., optim_type=optim_type, sign_value=-1.0, key=subkeys[4],prior=("l1l2", 0.001))
         self.W_mlp2 = HebbianSynapse(
                     f"{prefix}W_mlp2", shape=(4*n_embed, n_embed), batch_size= batch_size * seq_len, eta=eta, weight_init=dist.uniform(amin=wlb, amax=wub),
-                    bias_init=dist.constant(value=0.), w_bound=0., optim_type=optim_type, sign_value=-1.0, key=subkeys[5])
+                    bias_init=dist.constant(value=0.), w_bound=0., optim_type=optim_type, sign_value=-1.0, key=subkeys[5],prior=("l1l2", 0.001))
         self.e_mlp = ErrorCell(f"{prefix}e_mlp", n_units=n_embed, 
                                   batch_size=batch_size * seq_len) # shape=(seq_len, n_embed, 1),   
         self.e_mlp1 = ErrorCell(f"{prefix}e_mlp1", n_units= 4* n_embed, 

--- a/layers/mlp.py
+++ b/layers/mlp.py
@@ -21,10 +21,10 @@ class MLP:
         self.z_mlp2 = RateCell(f"{prefix}z_mlp2", n_units= 4* n_embed, tau_m= tau_m, act_fx="gelu", batch_size=batch_size * seq_len)
         
         self.W_mlp1 = HebbianSynapse(f"{prefix}W_mlp1", shape=(n_embed, 4*n_embed), batch_size = batch_size * seq_len, eta=eta, weight_init=dist.uniform(amin=wlb, amax=wub),
-                    bias_init=dist.constant(value=0.), w_bound=0., optim_type=optim_type, sign_value=1.0, key=subkeys[4])
+                    bias_init=dist.constant(value=0.), w_bound=0., optim_type=optim_type, sign_value=-1.0, key=subkeys[4])
         self.W_mlp2 = HebbianSynapse(
                     f"{prefix}W_mlp2", shape=(4*n_embed, n_embed), batch_size= batch_size * seq_len, eta=eta, weight_init=dist.uniform(amin=wlb, amax=wub),
-                    bias_init=dist.constant(value=0.), w_bound=0., optim_type=optim_type, sign_value=1.0, key=subkeys[5])
+                    bias_init=dist.constant(value=0.), w_bound=0., optim_type=optim_type, sign_value=-1.0, key=subkeys[5])
         self.e_mlp = ErrorCell(f"{prefix}e_mlp", n_units=n_embed, 
                                   batch_size=batch_size * seq_len) # shape=(seq_len, n_embed, 1),   
         self.e_mlp1 = ErrorCell(f"{prefix}e_mlp1", n_units= 4* n_embed, 

--- a/layers/mlp.py
+++ b/layers/mlp.py
@@ -21,10 +21,10 @@ class MLP:
         self.z_mlp2 = RateCell(f"{prefix}z_mlp2", n_units= 4* n_embed, tau_m= tau_m, act_fx="gelu", batch_size=batch_size * seq_len)
         
         self.W_mlp1 = HebbianSynapse(f"{prefix}W_mlp1", shape=(n_embed, 4*n_embed), batch_size = batch_size * seq_len, eta=eta, weight_init=dist.uniform(amin=wlb, amax=wub),
-                    bias_init=dist.constant(value=0.), w_bound=0., optim_type=optim_type, sign_value=-1.0, key=subkeys[4],prior=("l1l2", 0.001))
+                    bias_init=dist.constant(value=0.), w_bound=0., optim_type=optim_type, sign_value=-1.0, key=subkeys[4],prior=("l1l2", (0.001, 0.001)))
         self.W_mlp2 = HebbianSynapse(
                     f"{prefix}W_mlp2", shape=(4*n_embed, n_embed), batch_size= batch_size * seq_len, eta=eta, weight_init=dist.uniform(amin=wlb, amax=wub),
-                    bias_init=dist.constant(value=0.), w_bound=0., optim_type=optim_type, sign_value=-1.0, key=subkeys[5],prior=("l1l2", 0.001))
+                    bias_init=dist.constant(value=0.), w_bound=0., optim_type=optim_type, sign_value=-1.0, key=subkeys[5],prior=("l1l2", (0.001, 0.001)))
         self.e_mlp = ErrorCell(f"{prefix}e_mlp", n_units=n_embed, 
                                   batch_size=batch_size * seq_len) # shape=(seq_len, n_embed, 1),   
         self.e_mlp1 = ErrorCell(f"{prefix}e_mlp1", n_units= 4* n_embed, 

--- a/layers/output.py
+++ b/layers/output.py
@@ -1,7 +1,6 @@
-from ngclearn.utils import JaxProcess
-from jax import numpy as jnp, random, jit
+from jax import numpy as jnp, random
 from ngclearn.components import GaussianErrorCell as ErrorCell, RateCell, HebbianSynapse, StaticSynapse
-import ngclearn.utils.weight_distribution as dist
+from ngclearn.utils.distribution_generator import DistributionGenerator as dist
 from config import Config as config
 
 
@@ -30,8 +29,8 @@ class Output:
         
         self.W_out = HebbianSynapse(
                     "W_out", shape=(n_embed, vocab_size), batch_size= batch_size * seq_len, eta=eta, weight_init=dist.uniform(amin=wlb, amax=wub),
-                    bias_init=dist.constant(value=0.), w_bound=0., optim_type=optim_type, sign_value= -1.0, key=subkeys[4])
+                    bias_init=dist.constant(value=0.), w_bound=0., optim_type=optim_type, sign_value= 1.0, key=subkeys[4])
         self.e_out = ErrorCell("e_out", n_units=vocab_size, 
                                   batch_size=batch_size * seq_len) # shape=(seq_len, vocab_size, 1),
         self.E_out = StaticSynapse(
-                    "E_out", shape=(vocab_size, n_embed), weight_init=dist.uniform(amin=wlb, amax=wub), bias_init= dist.constant(value=0.), key=subkeys[4])
+                    "E_out", shape=(vocab_size, n_embed), weight_init=dist.uniform(low=wlb, high=wub), key=subkeys[4])

--- a/layers/output.py
+++ b/layers/output.py
@@ -29,7 +29,7 @@ class Output:
         
         self.W_out = HebbianSynapse(
                     "W_out", shape=(n_embed, vocab_size), batch_size= batch_size * seq_len, eta=eta, weight_init=dist.uniform(amin=wlb, amax=wub),
-                    bias_init=dist.constant(value=0.), w_bound=0., optim_type=optim_type, sign_value= 1.0, key=subkeys[4])
+                    bias_init=dist.constant(value=0.), w_bound=0., optim_type=optim_type, sign_value= -1.0, key=subkeys[4])
         self.e_out = ErrorCell("e_out", n_units=vocab_size, 
                                   batch_size=batch_size * seq_len) # shape=(seq_len, vocab_size, 1),
         self.E_out = StaticSynapse(

--- a/layers/output.py
+++ b/layers/output.py
@@ -29,7 +29,7 @@ class Output:
         
         self.W_out = HebbianSynapse(
                     "W_out", shape=(n_embed, vocab_size), batch_size= batch_size * seq_len, eta=eta, weight_init=dist.uniform(amin=wlb, amax=wub),
-                    bias_init=dist.constant(value=0.), w_bound=0., optim_type=optim_type, sign_value= -1.0, key=subkeys[4])
+                    bias_init=dist.constant(value=0.), w_bound=0., optim_type=optim_type, sign_value= -1.0, key=subkeys[4],prior=("l1l2", 0.001))
         self.e_out = ErrorCell("e_out", n_units=vocab_size, 
                                   batch_size=batch_size * seq_len) # shape=(seq_len, vocab_size, 1),
         self.E_out = StaticSynapse(

--- a/layers/output.py
+++ b/layers/output.py
@@ -29,7 +29,7 @@ class Output:
         
         self.W_out = HebbianSynapse(
                     "W_out", shape=(n_embed, vocab_size), batch_size= batch_size * seq_len, eta=eta, weight_init=dist.uniform(amin=wlb, amax=wub),
-                    bias_init=dist.constant(value=0.), w_bound=0., optim_type=optim_type, sign_value= -1.0, key=subkeys[4],prior=("l1l2", 0.001))
+                    bias_init=dist.constant(value=0.), w_bound=0., optim_type=optim_type, sign_value= -1.0, key=subkeys[4],prior=("l1l2", (0.001, 0.001)))
         self.e_out = ErrorCell("e_out", n_units=vocab_size, 
                                   batch_size=batch_size * seq_len) # shape=(seq_len, vocab_size, 1),
         self.E_out = StaticSynapse(

--- a/model.py
+++ b/model.py
@@ -1,12 +1,10 @@
+#import
 import jax
-from ngclearn.utils.model_utils import scanner
-from ngcsimlib.compilers import compile_command, wrap_command
-from ngcsimlib.context import Context
-from ngclearn.utils import JaxProcess
+from ngclearn import Context, MethodProcess
 from ngclearn.utils.io_utils import makedir
 from jax import numpy as jnp, random, jit
 from ngclearn.components import GaussianErrorCell as ErrorCell, RateCell, HebbianSynapse, StaticSynapse
-import ngclearn.utils.weight_distribution as dist
+from ngclearn.utils.distribution_generator import DistributionGenerator as dist
 from config import Config as config
 from layers.embedding import EMBEDDING
 from layers.attention import Attention
@@ -17,6 +15,9 @@ from layers.mlp import MLP
 from layers.output import Output
 from utils.model_util import ReshapeComponent
 from projection.projection import Projection
+import numpy as np
+
+
 
 class NGCTransformer:
     """
@@ -43,9 +44,9 @@ class NGCTransformer:
         model_name: unique model name
     """
 
-    def __init__(self, dkey, batch_size, seq_len, n_embed, vocab_size, n_layers, n_heads,  T,
-                 dt, tau_m, act_fx, eta, exp_dir,
-                 model_name, loadDir, pos_learnable, optim_type, wlb, wub , dropout_rate, **kwargs):
+   
+    def __init__(self, dkey, batch_size, seq_len, n_embed, vocab_size, n_layers, n_heads, T, dt, tau_m, act_fx, eta, dropout_rate, exp_dir, model_name, loadDir=None, pos_learnable=False, optim_type="adam", wub=1.0, wlb=0.0, **kwargs):
+
         self.exp_dir = exp_dir
         self.model_name = model_name
         self.nodes = None
@@ -55,170 +56,200 @@ class NGCTransformer:
         makedir(exp_dir + "/filters")
 
         dkey, *subkeys = random.split(dkey, 50)
-        if loadDir is not None:
-            self.load_from_disk(loadDir)
-        else:
-            with Context("Circuit") as self.circuit:
+       
+        with Context("Circuit") as self.circuit:
                 
-                self.embedding = EMBEDDING(dkey=subkeys[0], vocab_size=vocab_size, seq_len=seq_len, embed_dim=n_embed, batch_size=batch_size, pos_learnable=pos_learnable, eta=eta, optim_type=optim_type)
+            self.embedding = EMBEDDING(dkey=subkeys[0], vocab_size=vocab_size, seq_len=seq_len, embed_dim=n_embed, batch_size=batch_size, pos_learnable=pos_learnable, eta=eta, optim_type=optim_type)
                 
-                self.blocks = []
-                for i in range(n_layers):
-                    key, subkey = random.split(subkeys[1 + i])
-                    block=Block(dkey=subkey, block_id= i, n_embed=n_embed, seq_len=seq_len,
+            self.blocks = []
+            for i in range(n_layers):
+                key, subkey = random.split(subkeys[1 + i])
+                block=Block(dkey=subkey, block_id= i, n_embed=n_embed, seq_len=seq_len,
                                 batch_size=batch_size, vocab_size=vocab_size, n_heads=n_heads, dropout_rate=dropout_rate, eta=eta, optim_type=optim_type, wub=wub, wlb=wlb, tau_m=tau_m)
-                    self.blocks.append(block)   
+                self.blocks.append(block)   
                     
-                self.output = Output(dkey=subkeys[3], n_embed=n_embed, seq_len=seq_len, batch_size=batch_size, vocab_size=vocab_size, eta=eta, optim_type=optim_type, wlb=wlb, wub=wub, tau_m=tau_m)
+            self.output = Output(dkey=subkeys[3], n_embed=n_embed, seq_len=seq_len, batch_size=batch_size, vocab_size=vocab_size, eta=eta, optim_type=optim_type, wlb=wlb, wub=wub, tau_m=tau_m)
                 
-                self.z_target=RateCell("z_target", n_units= vocab_size, tau_m=0., act_fx="identity", batch_size=batch_size * seq_len) 
-                self.z_actfx= RateCell("z_actfx", n_units= vocab_size, tau_m=0., act_fx="softmax", batch_size=batch_size * seq_len)
-                
-                self.reshape_4d_to_2d = ReshapeComponent("reshape_4d_to_2d",
+            self.z_target=RateCell("z_target", n_units= vocab_size, tau_m=0., act_fx="identity", batch_size=batch_size * seq_len) 
+            self.z_actfx= RateCell("z_actfx", n_units= vocab_size, tau_m=0., act_fx="softmax", batch_size=batch_size * seq_len)
+            self.projection = Projection(dkey=subkeys[29], n_embed=n_embed, seq_len=seq_len, batch_size=batch_size,
+                                             vocab_size=vocab_size, eta=eta, optim_type=optim_type, pos_learnable=pos_learnable, wub=wub, wlb=wlb, n_blocks=n_layers, n_heads=n_heads, dropout_rate=dropout_rate)
+            self.reshape_4d_to_2d = ReshapeComponent("reshape_4d_to_2d",
                                             input_shape=(batch_size, seq_len, n_embed, 1),
                                             output_shape=(batch_size * seq_len, n_embed))
                 
-                self.reshape_3d_to_2d_embed = ReshapeComponent("reshape_3d_to_2d_embed",
+            self.reshape_3d_to_2d_embed = ReshapeComponent("reshape_3d_to_2d_embed",
                                             input_shape=(batch_size, seq_len, n_embed),
                                             output_shape=(batch_size * seq_len, n_embed))
-                self.reshape_2d_to_3d_embed= ReshapeComponent("reshape_2d_to_3d_embed",
+            self.reshape_2d_to_3d_embed= ReshapeComponent("reshape_2d_to_3d_embed",
                                             input_shape=(batch_size * seq_len, n_embed),
                                             output_shape=(batch_size, seq_len, n_embed))
                 
                 
-                self.embedding.W_embed.inputs << self.embedding.z_embed.zF  
-                self.reshape_3d_to_2d_embed.inputs << self.embedding.W_embed.outputs   
-                self.embedding.e_embed.mu << self.reshape_3d_to_2d_embed.outputs
-                self.embedding.e_embed.target << self.blocks[0].attention.z_qkv.z
+        if loadDir is not None:
+   
+            self.load_from_disk(loadDir,n_layers=n_layers)
+          
+        else:
+            with Context("Circuit") as self.circuit:
+            
                 
-                # self.reshape_4d_to_2d.inputs << self.attention.z_qkv.zF
+                self.embedding.W_embed.inputs >> self.embedding.z_embed.zF  
+                self.reshape_3d_to_2d_embed.inputs >> self.embedding.W_embed.outputs   
+                self.embedding.e_embed.mu >> self.reshape_3d_to_2d_embed.outputs
+                self.embedding.e_embed.target >> self.blocks[0].attention.z_qkv.z
+                
+                # self.reshape_4d_to_2d.inputs >> self.attention.z_qkv.zF
                 for blocks in range(n_layers):
                     block= self.blocks[blocks]
-                    block.attention.W_q.inputs << block.attention.z_qkv.zF
-                    block.attention.W_k.inputs << block.attention.z_qkv.zF
-                    block.attention.W_v.inputs << block.attention.z_qkv.zF
+                    block.attention.z_qkv.zF  >>  block.attention.W_q.inputs
+                    block.attention.z_qkv.zF >>   block.attention.W_k.inputs 
+                    block.attention.z_qkv.zF >>   block.attention.W_v.inputs
                     
-                    block.reshape_2d_to_3d_q.inputs << block.attention.W_q.outputs
-                    block.reshape_2d_to_3d_k.inputs << block.attention.W_k.outputs
-                    block.reshape_2d_to_3d_v.inputs << block.attention.W_v.outputs
+                    block.attention.W_q.outputs >> block.reshape_2d_to_3d_q.inputs 
+                    block.attention.W_k.outputs >> block.reshape_2d_to_3d_k.inputs 
+                    block.attention.W_v.outputs >> block.reshape_2d_to_3d_v.inputs 
                     
-                    block.attention.attn_block.inputs_q << block.reshape_2d_to_3d_q.outputs
-                    block.attention.attn_block.inputs_k << block.reshape_2d_to_3d_k.outputs       
-                    block.attention.attn_block.inputs_v << block.reshape_2d_to_3d_v.outputs
-                    
-                    block.reshape_3d_to_2d.inputs << block.attention.attn_block.outputs
-                    block.attention.W_attn_out.inputs << block.reshape_3d_to_2d.outputs
-                    block.attention.e_attn.mu << block.attention.W_attn_out.outputs
-                    block.attention.e_attn.target << block.mlp.z_mlp.z
+                    block.reshape_2d_to_3d_q.outputs >> block.attention.attn_block.inputs_q
+                    block.reshape_2d_to_3d_k.outputs >> block.attention.attn_block.inputs_k
+                    block.reshape_2d_to_3d_v.outputs >> block.attention.attn_block.inputs_v
+                    block.attention.attn_block.outputs >> block.reshape_3d_to_2d.inputs
 
-                    block.mlp.W_mlp1.inputs << block.mlp.z_mlp.zF
-                    block.mlp.e_mlp1.mu << block.mlp.W_mlp1.outputs
-                    block.mlp.e_mlp1.target << block.mlp.z_mlp2.z
+                    block.reshape_3d_to_2d.outputs >> block.attention.W_attn_out.inputs
+                    block.attention.W_attn_out.outputs >> block.attention.e_attn.mu
+                    block.mlp.z_mlp.z >> block.attention.e_attn.target
+
+
+                    block.mlp.z_mlp.zF >> block.mlp.W_mlp1.inputs
+                    block.mlp.W_mlp1.outputs >> block.mlp.e_mlp1.mu
+                    block.mlp.z_mlp2.z >> block.mlp.e_mlp1.target
+
+
+                    block.mlp.z_mlp2.zF >> block.mlp.W_mlp2.inputs
+                    block.mlp.W_mlp2.outputs >> block.mlp.e_mlp.mu
+
+     
                     
-                    
-                    block.mlp.W_mlp2.inputs << block.mlp.z_mlp2.zF
-                    block.mlp.e_mlp.mu << block.mlp.W_mlp2.outputs
-                    
-                    if blocks == n_layers -1:
-                        block.mlp.e_mlp.target << self.output.z_out.z
+                    if blocks == n_layers - 1:
+                        self.output.z_out.z >> block.mlp.e_mlp.target
                     else:
-                        block.mlp.e_mlp.target << self.blocks[blocks + 1].attention.z_qkv.z 
-                    block.attention.E_attn.inputs << block.attention.e_attn.dmu
-                
-                    block.mlp.E_mlp1.inputs << block.mlp.e_mlp1.dmu
-                    block.mlp.E_mlp.inputs << block.mlp.e_mlp.dmu
-                    block.attention.z_qkv.j << block.attention.E_attn.outputs
-                    
+                        self.blocks[blocks + 1].attention.z_qkv.z >> block.mlp.e_mlp.target
+
+
+                    block.attention.e_attn.dmu >> block.attention.E_attn.inputs
+
+                    block.mlp.e_mlp1.dmu >> block.mlp.E_mlp1.inputs
+                    block.mlp.e_mlp.dmu  >> block.mlp.E_mlp.inputs
+
+                    block.attention.E_attn.outputs >> block.attention.z_qkv.j
+
+
                     if blocks == 0:
-                        block.attention.z_qkv.j_td << self.embedding.e_embed.dtarget
+                        self.embedding.e_embed.dtarget >> block.attention.z_qkv.j_td
                     else:
-                        block.attention.z_qkv.j_td << block.mlp.e_mlp.dtarget
-                    block.mlp.z_mlp2.j << block.mlp.E_mlp.outputs
-                    block.mlp.z_mlp.j << block.mlp.E_mlp1.outputs
-                    block.mlp.z_mlp.j_td << block.attention.e_attn.dtarget
-                    block.mlp.z_mlp2.j_td << block.mlp.e_mlp1.dtarget
-                    block.attention.W_q.pre << block.attention.z_qkv.zF
-                    block.attention.W_q.post << block.attention.e_attn.dmu
-                    
-                    block.attention.W_k.pre << block.attention.z_qkv.zF
-                    block.attention.W_k.post << block.attention.e_attn.dmu
-                    
-                    block.attention.W_v.pre << block.attention.z_qkv.zF
-                    block.attention.W_v.post << block.attention.e_attn.dmu
-                    block.reshape_3d_to_2d_attnout.inputs << block.attention.attn_block.outputs
-                    block.attention.W_attn_out.pre << block.reshape_3d_to_2d_attnout.outputs
-                    block.attention.W_attn_out.post << block.attention.e_attn.dmu
-                                
-                    block.mlp.W_mlp1.pre << block.mlp.z_mlp.zF
-                    block.mlp.W_mlp1.post << block.mlp.e_mlp1.dmu
-                    block.mlp.W_mlp2.pre << block.mlp.z_mlp2.zF
-                    block.mlp.W_mlp2.post << block.mlp.e_mlp.dmu
+                        block.mlp.e_mlp.dtarget >> block.attention.z_qkv.j_td
+
+
+                    block.mlp.E_mlp.outputs  >> block.mlp.z_mlp2.j
+                    block.mlp.E_mlp1.outputs >> block.mlp.z_mlp.j
+
+                    block.attention.e_attn.dtarget >> block.mlp.z_mlp.j_td
+                    block.mlp.e_mlp1.dtarget       >> block.mlp.z_mlp2.j_td
+
+
+                    block.attention.z_qkv.zF >> block.attention.W_q.pre
+                    block.attention.e_attn.dmu >> block.attention.W_q.post
+
+                    block.attention.z_qkv.zF >> block.attention.W_k.pre
+                    block.attention.e_attn.dmu >> block.attention.W_k.post
+
+                    block.attention.z_qkv.zF >> block.attention.W_v.pre
+                    block.attention.e_attn.dmu >> block.attention.W_v.post
+
+
+                    block.attention.attn_block.outputs >> block.reshape_3d_to_2d_attnout.inputs
+                    block.reshape_3d_to_2d_attnout.outputs >> block.attention.W_attn_out.pre
+                    block.attention.e_attn.dmu >> block.attention.W_attn_out.post
+
+
+                    block.mlp.z_mlp.zF  >> block.mlp.W_mlp1.pre
+                    block.mlp.e_mlp1.dmu >> block.mlp.W_mlp1.post
+
+                    block.mlp.z_mlp2.zF >> block.mlp.W_mlp2.pre
+                    block.mlp.e_mlp.dmu  >> block.mlp.W_mlp2.post
+
                         
-                self.output.W_out.inputs << self.output.z_out.zF
-                self.z_actfx.j << self.output.W_out.outputs
-                self.output.e_out.mu << self.z_actfx.zF
-                self.output.e_out.target << self.z_target.z
-            
-                self.output.E_out.inputs << self.output.e_out.dmu
-                
-                
-                self.output.z_out.j << self.output.E_out.outputs
-                self.output.z_out.j_td << self.blocks[n_layers - 1].mlp.e_mlp.dtarget
-                
-                
-                # self.W_embed.pre << self.z_embed.zF
-                self.reshape_2d_to_3d_embed.inputs << self.embedding.e_embed.dmu 
-                self.embedding.W_embed.post << self.reshape_2d_to_3d_embed.outputs 
-                
-                self.output.W_out.pre << self.output.z_out.zF
-                self.output.W_out.post << self.output.e_out.dmu      
-               
-        
-        
-        
+                self.output.z_out.zF >> self.output.W_out.inputs
+                self.output.W_out.outputs >> self.z_actfx.j
+
+                self.z_actfx.zF >> self.output.e_out.mu
+                self.z_target.z >> self.output.e_out.target
+
+                self.output.e_out.dmu >> self.output.E_out.inputs
+
+
+                self.output.E_out.outputs >> self.output.z_out.j
+                self.blocks[n_layers - 1].mlp.e_mlp.dtarget >> self.output.z_out.j_td
+
+
+                self.embedding.e_embed.dmu >> self.reshape_2d_to_3d_embed.inputs
+                self.reshape_2d_to_3d_embed.outputs >> self.embedding.W_embed.post
+
+
+                self.output.z_out.zF >> self.output.W_out.pre
+                self.output.e_out.dmu >> self.output.W_out.post
+
+                        
+                        
                 ## PROJECTION PHASE ##
                 
-                self.projection = Projection(dkey=subkeys[29], n_embed=n_embed, seq_len=seq_len, batch_size=batch_size,
-                                             vocab_size=vocab_size, eta=eta, optim_type=optim_type, pos_learnable=pos_learnable, wub=wub, wlb=wlb, n_blocks=n_layers, n_heads=n_heads, dropout_rate=dropout_rate)
                 
                 
-                self.projection.Q_embed.inputs << self.projection.q_embed.zF
-                self.projection.reshape_3d_to_2d_proj.inputs << self.projection.Q_embed.outputs
+                self.projection.q_embed_Ratecell.zF >> self.projection.Q_embed.inputs
+                self.projection.Q_embed.outputs >> self.projection.reshape_3d_to_2d_proj.inputs
+
                 for b in range(n_layers):
-                    block_proj= self.projection.blocks[b]
-                    if b ==0:
-                       block_proj.q_qkv.j << self.projection.reshape_3d_to_2d_proj.outputs
+                    block_proj = self.projection.blocks[b]
+
+                    if b == 0:
+                        self.projection.reshape_3d_to_2d_proj.outputs >> block_proj.q_qkv_Ratecell.j
                     else:
-                       block_proj.q_qkv.j << self.projection.blocks[b - 1].Q_mlp2.outputs
-                       
-                    block_proj.Q_q.inputs << block_proj.q_qkv.zF
-                    block_proj.Q_k.inputs << block_proj.q_qkv.zF
-                    block_proj.Q_v.inputs << block_proj.q_qkv.zF
-                    block_proj.q_attn_block.inputs_q << block_proj.Q_q.outputs
-                    block_proj.q_attn_block.inputs_k << block_proj.Q_k.outputs
-                    block_proj.q_attn_block.inputs_v << block_proj.Q_v.outputs
-                    
-                    block_proj.reshape_3d_to_2d_proj1.inputs << block_proj.q_attn_block.outputs
-                    block_proj.Q_attn_out.inputs << block_proj.reshape_3d_to_2d_proj1.outputs
-                    block_proj.q_mlp.j << block_proj.Q_attn_out.outputs
-                    
-                    block_proj.Q_mlp1.inputs << block_proj.q_mlp.zF
-                    block_proj.q_mlp2.j << block_proj.Q_mlp1.outputs
-                    block_proj.Q_mlp2.inputs << block_proj.q_mlp2.zF
-                self.projection.q_out.j << self.projection.blocks[n_layers - 1].Q_mlp2.outputs
-                self.projection.Q_out.inputs << self.projection.q_out.zF
-                self.projection.q_target.j <<self.projection.Q_out.outputs
-                # self.projection.eq_target.target << self.projection.q_target.z
-                self.projection.eq_target.mu << self.projection.q_target.z
+                        self.projection.blocks[b - 1].Q_mlp2.outputs >> block_proj.q_qkv_Ratecell.j
+
+                    block_proj.q_qkv_Ratecell.zF >> block_proj.Q_q.inputs
+                    block_proj.q_qkv_Ratecell.zF >> block_proj.Q_k.inputs
+                    block_proj.q_qkv_Ratecell.zF >> block_proj.Q_v.inputs
+
+                    block_proj.Q_q.outputs >> block_proj.q_attn_block.inputs_q
+                    block_proj.Q_k.outputs >> block_proj.q_attn_block.inputs_k
+                    block_proj.Q_v.outputs >> block_proj.q_attn_block.inputs_v
+
+                    block_proj.q_attn_block.outputs >> block_proj.reshape_3d_to_2d_proj1.inputs
+                    block_proj.reshape_3d_to_2d_proj1.outputs >> block_proj.Q_attn_out.inputs
+                    block_proj.Q_attn_out.outputs >> block_proj.q_mlp_Ratecell.j
+
+                    block_proj.q_mlp_Ratecell.zF >> block_proj.Q_mlp1.inputs
+                    block_proj.Q_mlp1.outputs >> block_proj.q_mlp2_Ratecell.j
+                    block_proj.q_mlp2_Ratecell.zF >> block_proj.Q_mlp2.inputs
+
+                self.projection.blocks[n_layers - 1].Q_mlp2.outputs >> self.projection.q_out_Ratecell.j
+                self.projection.q_out_Ratecell.zF >> self.projection.Q_out.inputs
+                self.projection.Q_out.outputs >> self.projection.q_target_Ratecell.j
+
+                self.projection.q_target_Ratecell.z >> self.projection.eq_target.mu
+
                 
                 # Create the processes by iterating through all blocks
-                advance_process = JaxProcess(name="advance_process")
-                reset_process = JaxProcess(name="reset_process")
-                embedding_evolve_process = (JaxProcess(name="embedding_evolve_process")
-                                            >> self.embedding.W_embed.evolve) 
-                evolve_process = JaxProcess(name="evolve_process")
-                project_process = JaxProcess(name="project_process")
-                
+                advance_process = MethodProcess(name="advance_process")
+                reset_process = MethodProcess(name="reset_process") 
+                embedding_evolve_process = MethodProcess(name="embedding_evolve_process")
+                                           
+                evolve_process = MethodProcess(name="evolve_process")
+                project_process = MethodProcess(name="project_process")
+                embedding_evolve_process  >> self.embedding.W_embed.evolve
+
+
+
                 advance_process >> self.embedding.z_embed.advance_state
                 advance_process >> self.embedding.W_embed.advance_state
                 advance_process >> self.reshape_3d_to_2d_embed.advance_state
@@ -246,9 +277,7 @@ class NGCTransformer:
                     advance_process >> block.mlp.W_mlp1.advance_state
                     advance_process >> block.mlp.W_mlp2.advance_state
                     advance_process >> block.attention.e_attn.advance_state
-                    advance_process >> block.mlp.e_mlp1.advance_state
                     advance_process >> block.mlp.e_mlp.advance_state
-    
                     
                     reset_process >> block.attention.z_qkv.reset
                     reset_process >> block.mlp.z_mlp.reset
@@ -270,16 +299,15 @@ class NGCTransformer:
                     evolve_process >> block.mlp.W_mlp2.evolve
 
                 # Add non-block components to advance_process, reset_process, evolve_process
-                advance_process >> self.z_target.advance_state
                 advance_process >> self.output.E_out.advance_state
                 advance_process >> self.output.z_out.advance_state
                 advance_process >> self.output.W_out.advance_state
                 advance_process >> self.z_actfx.advance_state
                 advance_process >> self.output.e_out.advance_state
 
-                reset_process >> self.projection.q_embed.reset
-                reset_process >> self.projection.q_out.reset
-                reset_process >> self.projection.q_target.reset
+                reset_process >> self.projection.q_embed_Ratecell.reset
+                reset_process >> self.projection.q_out_Ratecell.reset
+                reset_process >> self.projection.q_target_Ratecell.reset
                 reset_process >> self.projection.eq_target.reset
                 reset_process >> self.embedding.z_embed.reset
                 reset_process >> self.output.z_out.reset
@@ -291,99 +319,65 @@ class NGCTransformer:
                 reset_process >> self.reshape_2d_to_3d_embed.reset
 
                 evolve_process >> self.output.W_out.evolve
-                project_process >> self.projection.q_embed.advance_state
+                project_process >> self.projection.q_embed_Ratecell.advance_state
                 project_process >> self.projection.Q_embed.advance_state
                 project_process >> self.projection.reshape_3d_to_2d_proj.advance_state
                 for b in range(n_layers):
                     block_proj= self.projection.blocks[b]
-                    project_process >> block_proj.q_qkv.advance_state
+                    project_process >> block_proj.q_qkv_Ratecell.advance_state
                     project_process >> block_proj.Q_q.advance_state
                     project_process >> block_proj.Q_k.advance_state
                     project_process >> block_proj.Q_v.advance_state
                     project_process >> block_proj.q_attn_block.advance_state
                     project_process >> block_proj.reshape_3d_to_2d_proj1.advance_state
                     project_process >> block_proj.Q_attn_out.advance_state
-                    project_process >> block_proj.q_mlp.advance_state
-                    project_process >> block_proj.q_mlp2.advance_state
+                    project_process >> block_proj.q_mlp_Ratecell.advance_state
+                    project_process >> block_proj.q_mlp2_Ratecell.advance_state
                     project_process >> block_proj.Q_mlp1.advance_state
                     project_process >> block_proj.Q_mlp2.advance_state
-                    reset_process >> block_proj.q_qkv.reset
+                    reset_process >> block_proj.q_qkv_Ratecell.reset
                     reset_process >> block_proj.q_attn_block.reset
-                    reset_process >> block_proj.q_mlp.reset
-                    reset_process >> block_proj.q_mlp2.reset 
-                project_process >> self.projection.q_out.advance_state
+                    reset_process >> block_proj.q_mlp_Ratecell.reset
+                    reset_process >> block_proj.q_mlp2_Ratecell.reset 
+                project_process >> self.projection.q_out_Ratecell.advance_state
                 project_process >> self.projection.Q_out.advance_state
-                project_process >> self.projection.q_target.advance_state
+                project_process >> self.projection.q_target_Ratecell.advance_state
                 project_process >> self.projection.eq_target.advance_state
                 
-                processes = (reset_process, advance_process, embedding_evolve_process, evolve_process, project_process)        
+               
+                self.reset = reset_process
+                self.advance = advance_process
+                self.evolve = evolve_process
+                self.project = project_process
+                self.embedding_evolve=embedding_evolve_process
 
-                self._dynamic(processes)
+                
+
+
     
-    def _dynamic(self, processes):
-        vars = self.circuit.get_components( "reshape_3d_to_2d_embed", "reshape_2d_to_3d_embed",
-            "q_embed", "q_out", "reshape_3d_to_2d_proj", "q_target", "eq_target","Q_embed", "Q_out",
-                                           "z_embed","z_target", "z_out", "z_actfx", "e_embed", "e_out", "W_embed", "W_out", "E_out")
-        (self.reshape_3d_to_2d_embed,  self.reshape_2d_to_3d_embed, self.q_embed, self.q_out, self.reshape_3d_to_2d_proj, 
-        self.q_target, self.eq_target, self.Q_embed, self.Q_out,
-        self.embedding.z_embed, self.z_target, self.output.z_out, self.z_actfx, self.embedding.e_embed, self.output.e_out, self.embedding.W_embed,
-        self.output.W_out, self.output.E_out) = vars
-        self.block_components = []  
+    def clamp_input(self,x):
+        self.embedding.z_embed.j.set(x)
+        self.projection.q_embed_Ratecell.j.set(x) 
+        
     
-        for i in range(self.n_layers):
-            var2 = self.circuit.get_components(
-                f"block{i}_z_qkv", f"block{i}_e_attn", f"block{i}_W_q", f"block{i}_W_k", f"block{i}_W_v",
-                f"block{i}_W_attn_out", f"block{i}_E_attn", f"block{i}_z_mlp", f"block{i}_e_mlp",
-                f"block{i}_W_mlp1", f"block{i}_W_mlp2", f"block{i}_E_mlp", f"block{i}_e_mlp1", f"block{i}_E_mlp1",
-                f"block{i}_z_mlp2", f"block{i}_attn_block",
-                f"block{i}_reshape_2d_to_3d_q", f"block{i}_reshape_2d_to_3d_k", f"block{i}_reshape_2d_to_3d_v",
-                f"block{i}_reshape_3d_to_2d", f"block{i}_reshape_3d_to_2d_attnout",
-                f"proj_block{i}_q_qkv", f"proj_block{i}_Q_q", f"proj_block{i}_Q_k", f"proj_block{i}_Q_v",
-                f"proj_block{i}_Q_attn_out", f"proj_block{i}_q_attn_block",
-                f"proj_block{i}_reshape_3d_to_2d_proj1", f"proj_block{i}_q_mlp", f"proj_block{i}_Q_mlp1",
-                f"proj_block{i}_q_mlp2", f"proj_block{i}_Q_mlp2"    
-            )
-            
-            self.block_components.append(var2)
-        
-        all_nodes = list(vars)
-        for block_vars in self.block_components:
-            all_nodes.extend(block_vars)
-        self.nodes = all_nodes
+    def clamp_target(self,y):
+        self.z_target.j.set(y)
 
-        reset_proc, advance_proc, embedding_evolve_process, evolve_proc, project_proc = processes
-
-        self.circuit.wrap_and_add_command(jit(reset_proc.pure), name="reset")
-        self.circuit.wrap_and_add_command(jit(advance_proc.pure), name="advance")
-        self.circuit.wrap_and_add_command(jit(project_proc.pure), name="project")
-        self.circuit.wrap_and_add_command(jit(evolve_proc.pure), name="evolve")
-        self.circuit.wrap_and_add_command(jit(embedding_evolve_process.pure), name="evolve_embedding")
-
-
-        @Context.dynamicCommand
-        def clamp_input(x):
-            self.embedding.z_embed.j.set(x)
-            self.q_embed.j.set(x) 
-        
-        @Context.dynamicCommand
-        def clamp_target(y):
-            self.z_target.j.set(y)
-
-        @Context.dynamicCommand
-        def clamp_infer_target(y):
-            self.eq_target.target.set(y)
+    
+    def clamp_infer_target(self,y):
+        self.projection.eq_target.target.set(y)
         
     def save_to_disk(self, params_only=False):
         """
-        Saves current model parameter values to disk
+        Saves current model parameter get()s to disk
 
         Args:
             params_only: if True, save only param arrays to disk (and not JSON sim/model structure)
         """
         if params_only:
-            model_dir = "{}/{}/custom".format(self.exp_dir, self.model_name)
+            model_dir = "{}/{}/component/custom".format(self.exp_dir, self.model_name)
             self.embedding.W_embed.save(model_dir)
-            # self.blocks = []
+            self.blocks = []
             for j in range(self.n_layers):
                 block = self.circuit.get_components(f"block{j}_W_q")
                 block.save(model_dir)
@@ -400,111 +394,175 @@ class NGCTransformer:
             self.output.W_out.save(model_dir)
         else:
             self.circuit.save_to_json(self.exp_dir, model_name=self.model_name, overwrite=True)
+            
 
-    def load_from_disk(self, model_directory):
-        """
-        Loads parameter/config values from disk to this model
+    def load_from_disk(self, model_directory, n_layers=1):
+        self.circuit = Context.load(directory=model_directory, module_name=self.model_name)
+       
+        processes = self.circuit.get_objects_by_type("process")
+        self.advance = processes.get("advance_process")
+        self.reset   = processes.get("reset_process")
+        self.evolve  = processes.get("evolve_process")
+        self.project = processes.get("project_process")
 
-        Args:
-            model_directory: directory/path to saved model parameter/config values
-        """
-        print(" > Loading model from ",model_directory)
-        with Context("Circuit") as self.circuit:
-            self.circuit.load_from_dir(model_directory)
-            processes = (
-                self.circuit.reset_process, self.circuit.advance_process,
-                self.circuit.evolve_process, self.circuit.project_process
-            )
-            self._dynamic(processes)
+        self.embedding_evolve = processes.get("embedding_evolve_process", self.evolve) 
+
+        self.embedding.W_embed.word_weights.set(self.circuit.get_components("W_embed").word_weights.get())
+        self.embedding.W_embed.pos_weights.set(self.circuit.get_components("W_embed").pos_weights.get())
+        self.output.W_out.weights.set(self.circuit.get_components("W_out").weights.get())
+        self.output.W_out.biases.set(self.circuit.get_components("W_out").biases.get())
+      
+        self.projection.q_out_Ratecell.z.set( self.circuit.get_components("q_out_Ratecell").z.get())
+        self.projection.eq_target.dmu.set( self.circuit.get_components("eq_target").dmu.get())
+        self.projection.eq_target.dtarget.set( self.circuit.get_components("eq_target").dtarget.get())
+   
+        self.projection.q_target_Ratecell.z.set(self.circuit.get_components("q_target").z.get())
+        self.output.W_out.outputs.set( self.circuit.get_components("W_out").outputs.get())
+        self.embedding.e_embed.L.set( self.circuit.get_components("e_embed").L.get())
+        self.output.e_out.L.set( self.circuit.get_components("e_out").L.get())
+        self.projection.reshape_3d_to_2d_proj.inputs.set(self.circuit.get_components("reshape_3d_to_2d_proj").inputs.get())
+        self.projection.reshape_3d_to_2d_proj.outputs.set(self.circuit.get_components("reshape_3d_to_2d_proj").outputs.get())
+      
+
+        # --- B. Map Block Components (Loop) ---
+        for i in range(n_layers):
+         
+            b_prefix = f"block{i}"
+            p_prefix = f"block_proj{i}"
+            block_proj= self.projection.blocks[i]
+            block= self.blocks[i] 
+            
+            # --- Map Attention Sub-block ---
+          
+            block.attention.W_q.weights.set( self.circuit.get_components(f"{b_prefix}_W_q").weights.get())
+            block.attention.W_k.weights.set( self.circuit.get_components(f"{b_prefix}_W_k").weights.get())
+            block.attention.W_v.weights.set( self.circuit.get_components(f"{b_prefix}_W_v").weights.get())
+            block.attention.W_q.biases.set( self.circuit.get_components(f"{b_prefix}_W_q").biases.get())
+            block.attention.W_k.biases.set( self.circuit.get_components(f"{b_prefix}_W_k").biases.get())
+            block.attention.W_v.biases.set( self.circuit.get_components(f"{b_prefix}_W_v").biases.get())
+            block.attention.attn_block.inputs_q.set(self.circuit.get_components(f"{b_prefix}_attn_block").inputs_q.get())
+            block.attention.attn_block.inputs_k.set(self.circuit.get_components(f"{b_prefix}_attn_block").inputs_k.get())
+            block.attention.attn_block.inputs_v.set(self.circuit.get_components(f"{b_prefix}_attn_block").inputs_v.get())
+            block.attention.W_attn_out.weights.set(self.circuit.get_components(f"{b_prefix}_W_attn_out").weights.get())
+            block.attention.W_attn_out.biases.set(self.circuit.get_components(f"{b_prefix}_W_attn_out").biases.get())
+
+            block.attention.e_attn.L.set(self.circuit.get_components(f"{b_prefix}_e_attn").L.get())
+            block.mlp.e_mlp.L.set(self.circuit.get_components(f"{b_prefix}_e_mlp").L.get())
+            block.mlp.e_mlp1.L.set(self.circuit.get_components(f"{b_prefix}_e_mlp1").L.get())
+            # --- Map MLP Sub-block ---
+            block.mlp.z_mlp.z.set(   self.circuit.get_components(f"{b_prefix}_z_mlp"))
+            block.mlp.z_mlp2.z.set(  self.circuit.get_components(f"{b_prefix}_z_mlp2"))
+            block.mlp.W_mlp1.weights.set(self.circuit.get_components(f"{b_prefix}_W_mlp1").weights.get())
+            block.mlp.W_mlp2.weights.set(self.circuit.get_components(f"{b_prefix}_W_mlp2").weights.get())
+            block.mlp.W_mlp1.biases.set(self.circuit.get_components(f"{b_prefix}_W_mlp1").biases.get())
+            block.mlp.W_mlp2.biases.set(self.circuit.get_components(f"{b_prefix}_W_mlp2").biases.get())
+
+            # --- Map Projection Block ---
+            block_proj.q_qkv_Ratecell.z.set(  self.circuit.get_components(f"{p_prefix}_q_qkv_Ratecell").z.get())
+            block_proj.q_mlp_Ratecell.z.set(  self.circuit.get_components(f"{p_prefix}_q_mlp_Ratecell").z.get())
+            block_proj.q_mlp2_Ratecell.z.set(  self.circuit.get_components(f"{p_prefix}_q_mlp2_Ratecell").z.get())
+            block_proj.reshape_3d_to_2d_proj1.inputs.set(self.circuit.get_components(f"{p_prefix}_reshape_3d_to_2d_proj1").inputs.get())
+            
+            block_proj.reshape_3d_to_2d_proj1.outputs.set(self.circuit.get_components(f"{p_prefix}_reshape_3d_to_2d_proj1").outputs.get())
+            block_proj.q_attn_block = self.circuit.get_components(f"{p_prefix}_q_attn_block")
+          
+            
+            
+  
+
+
 
     def process(self, obs, lab, adapt_synapses=True):
-        eps = 0.001
-        # scale = 1.0 / jnp.sqrt(config.n_embed) 
-        self.circuit.reset()
-
-        ## pin/tie inference synapses to be exactly equal to the forward ones
-        self.Q_embed.word_weights.set(self.embedding.W_embed.word_weights.value)
+        
+   
+     
+        self.reset.run()
+        self.projection.Q_embed.word_weights.set(self.embedding.W_embed.word_weights.get())
         if self.embedding.W_embed.pos_learnable:
-           self.Q_embed.pos_weights.set(self.embedding.W_embed.pos_weights.value)
+           self.projection.Q_embed.pos_weights.set(self.embedding.W_embed.pos_weights.get())
         for i in range(self.n_layers):
             block_proj= self.projection.blocks[i]
-            block= self.blocks[i]
-            block_proj.Q_q.weights.set(block.attention.W_q.weights.value)
-            block_proj.Q_q.biases.set(block.attention.W_q.biases.value)
-            block_proj.Q_k.weights.set(block.attention.W_k.weights.value)
-            block_proj.Q_k.biases.set(block.attention.W_k.biases.value)
-            block_proj.Q_v.weights.set(block.attention.W_v.weights.value)
-            block_proj.Q_v.biases.set(block.attention.W_v.biases.value)
-            block_proj.Q_attn_out.weights.set(block.attention.W_attn_out.weights.value)
-            block_proj.q_attn_block.inputs_q.set(block.attention.attn_block.inputs_q.value)
-            block_proj.q_attn_block.inputs_k.set(block.attention.attn_block.inputs_k.value)
-            block_proj.q_attn_block.inputs_v.set(block.attention.attn_block.inputs_v.value)
-            block_proj.Q_attn_out.biases.set(block.attention.W_attn_out.biases.value)
-            block_proj.Q_mlp1.weights.set(block.mlp.W_mlp1.weights.value)
-            block_proj.Q_mlp1.biases.set(block.mlp.W_mlp1.biases.value)
-            block_proj.Q_mlp2.weights.set(block.mlp.W_mlp2.weights.value)
-            block_proj.Q_mlp2.biases.set(block.mlp.W_mlp2.biases.value)
-            
-            ## pin/tie feedback synapses to transpose of forward ones
+            block= self.blocks[i] 
+            block_proj.Q_q.weights.set(block.attention.W_q.weights.get())
+            block_proj.Q_q.biases.set(block.attention.W_q.biases.get())
+            block_proj.Q_k.weights.set(block.attention.W_k.weights.get())
+            block_proj.Q_k.biases.set(block.attention.W_k.biases.get())
+            block_proj.Q_v.weights.set(block.attention.W_v.weights.get())
+            block_proj.Q_v.biases.set(block.attention.W_v.biases.get())
+            block_proj.Q_attn_out.weights.set(block.attention.W_attn_out.weights.get())
+            block_proj.q_attn_block.inputs_q.set(block.attention.attn_block.inputs_q.get())
+            block_proj.q_attn_block.inputs_k.set(block.attention.attn_block.inputs_k.get())
+            block_proj.q_attn_block.inputs_v.set(block.attention.attn_block.inputs_v.get())
+            block_proj.Q_attn_out.biases.set(block.attention.W_attn_out.biases.get())
+            block_proj.Q_mlp1.weights.set(block.mlp.W_mlp1.weights.get())
+            block_proj.Q_mlp1.biases.set(block.mlp.W_mlp1.biases.get())
+            block_proj.Q_mlp2.weights.set(block.mlp.W_mlp2.weights.get())
+            block_proj.Q_mlp2.biases.set(block.mlp.W_mlp2.biases.get())
 
-            block.attention.E_attn.weights.set(jnp.transpose(block.attention.W_attn_out.weights.value))
-            block.mlp.E_mlp.weights.set(jnp.transpose(block.mlp.W_mlp2.weights.value))  
-            block.mlp.E_mlp1.weights.set(jnp.transpose(block.mlp.W_mlp1.weights.value))
+            block.attention.z_qkv.z.set(block_proj.q_qkv_Ratecell.z.get())
+            block.mlp.z_mlp.z.set(block_proj.q_mlp_Ratecell.z.get())
+            block.mlp.z_mlp2.z.set(block_proj.q_mlp2_Ratecell.z.get())
+            block.attention.E_attn.weights.set(jnp.transpose(block.attention.W_attn_out.weights.get()))
+            block.mlp.E_mlp.weights.set(jnp.transpose(block.mlp.W_mlp2.weights.get()))  
+            block.mlp.E_mlp1.weights.set(jnp.transpose(block.mlp.W_mlp1.weights.get()))
   
-        self.projection.Q_out.weights.set(self.output.W_out.weights.value)
-        self.projection.Q_out.biases.set(self.output.W_out.biases.value)
-        self.projection.q_target.j_td.set(jnp.zeros((config.batch_size * config.seq_len, config.vocab_size)))
+        self.projection.Q_out.weights.set(self.output.W_out.weights.get())
+        self.projection.Q_out.biases.set(self.output.W_out.biases.get())
+        self.projection.q_target_Ratecell.j_td.set(jnp.zeros((config.batch_size * config.seq_len, config.vocab_size)))
         
-        ## pin/tie feedback synapses to transpose of forward ones
        
-        self.output.E_out.weights.set(jnp.transpose(self.output.W_out.weights.value))
+
+        self.output.E_out.weights.set(jnp.transpose(self.output.W_out.weights.get()))
+       
+        self.clamp_input(obs)
+        self.clamp_infer_target(lab)
+
+
+
+
         
-        ## Perform P-step (projection step)
-        self.circuit.clamp_input(obs)
-        self.circuit.clamp_infer_target(lab)
-        self.circuit.project(t=0., dt=1.)
-        # initialize dynamics of generative model latents to projected states for the errors it's 0
-        for i in range(self.n_layers):
-            self.blocks[i].attention.z_qkv.z.set(self.projection.blocks[i].q_qkv.z.value)
-            self.blocks[i].mlp.z_mlp.z.set(self.projection.blocks[i].q_mlp.z.value)
-            self.blocks[i].mlp.z_mlp2.z.set(self.projection.blocks[i].q_mlp2.z.value)
-        self.output.z_out.z.set(self.projection.q_out.z.value)
-        self.output.e_out.dmu.set(self.projection.eq_target.dmu.value)
-        self.output.e_out.dtarget.set(self.projection.eq_target.dtarget.value)
+        self.project.run(t=0., dt=1.)
+
+
+
+        
+        self.output.z_out.z.set(self.projection.q_out_Ratecell.z.get())
+        self.output.e_out.dmu.set(self.projection.eq_target.dmu.get())
+        self.output.e_out.dtarget.set(self.projection.eq_target.dtarget.get())
         
         
         ## get projected prediction (from the P-step)
-        y_mu_inf = self.q_target.z.value
+        y_mu_inf = self.projection.q_target_Ratecell.z.get()
     
-        EFE = 0. ## expected free energy
+        EFE = 0. 
         y_mu = 0.
         if adapt_synapses:
             for ts in range(0, self.T):
-                self.circuit.clamp_input(obs) ## clamp input data to z_embed & q_embed input compartments
-                self.circuit.clamp_target(lab) ## clamp target data to z_target
-                self.circuit.advance(t=ts, dt=1.)
+        
+                self.clamp_input(obs)
+                self.clamp_target(lab)
+             
+                self.advance.run(t=ts,dt=1.)
            
-        y_mu = self.output.W_out.outputs.value ## get settled prediction
+        y_mu = self.output.W_out.outputs.get() 
 
-        L1 = self.embedding.e_embed.L.value
-        L4 = self.output.e_out.L.value
-            # Sum errors from ALL blocks
+        L1 = self.embedding.e_embed.L.get()
+        L4 = self.output.e_out.L.get()
+        
         block_errors = 0.
         for i in range(self.n_layers):
                 block = self.blocks[i]
-                block_errors += block.attention.e_attn.L.value + block.mlp.e_mlp.L.value + block.mlp.e_mlp1.L.value
-        L_attn= self.blocks[self.n_layers - 1].attention.e_attn.L.value
-        L_mlp1 = self.blocks[self.n_layers - 1].mlp.e_mlp1.L.value
-        L_mlp2 = self.blocks[self.n_layers - 1].mlp.e_mlp.L.value
-        EFE = L4 + L_attn + L_mlp1 + L_mlp2 + L1
+                block_errors += block.attention.e_attn.L.get() + block.mlp.e_mlp.L.get() + block.mlp.e_mlp1.L.get()
+
+        EFE = L4 + block_errors + L1
 
         if adapt_synapses == True:
-                self.circuit.evolve()
-                self.circuit.evolve_embedding()
+                self.embedding_evolve.run()
+                self.evolve.run(t=self.T,dt=1.)
+                
         ## skip E/M steps if just doing test-time inference
-        return y_mu_inf, y_mu, EFE
+        return y_mu_inf, y_mu, EFE 
 
     def get_latents(self):
-        return self.q_out.z.value
-    
-    
+        return self.q_out_Ratecell.z.get()
+  

--- a/model.py
+++ b/model.py
@@ -303,6 +303,7 @@ class NGCTransformer:
                 advance_process >> self.output.z_out.advance_state
                 advance_process >> self.output.W_out.advance_state
                 advance_process >> self.z_actfx.advance_state
+                advance_process >> self.z_target.advance_state
                 advance_process >> self.output.e_out.advance_state
 
                 reset_process >> self.projection.q_embed_Ratecell.reset

--- a/projection/proj_block.py
+++ b/projection/proj_block.py
@@ -1,7 +1,7 @@
 from config import Config as config
 from ngclearn.components import GaussianErrorCell as ErrorCell, RateCell, HebbianSynapse, StaticSynapse
 from utils.attention_utils import _compute_attention, AttentionBlock
-import ngclearn.utils.weight_distribution as dist
+from ngclearn.utils.distribution_generator import DistributionGenerator as dist
 from layers.mlp import MLP
 from jax import jit, random
 import jax.numpy as jnp
@@ -13,42 +13,38 @@ class ProjBlock:
                  batch_size, n_heads, dropout_rate, eta, optim_type, wub, wlb, **kwargs):
         
         dkey, *subkeys = random.split(dkey, 20)
-        prefix = f"proj_block{block_id}_"
-    
-        self.q_qkv = RateCell(f"{prefix}q_qkv", n_units=n_embed, tau_m=0., act_fx="identity",
+        prefix = f"block_proj{block_id}_"
+     
+        self.q_qkv_Ratecell = RateCell(f"{prefix}q_qkv_Ratecell", n_units=n_embed, tau_m=0., act_fx="identity",
                           batch_size=batch_size * seq_len)
-        self.q_mlp = RateCell(f"{prefix}q_mlp", n_units= n_embed, tau_m=0., act_fx="identity",
+        self.q_mlp_Ratecell = RateCell(f"{prefix}q_mlp_Ratecell", n_units= n_embed, tau_m=0., act_fx="identity",
                            batch_size= batch_size * seq_len)
-        self.q_mlp2 = RateCell(f"{prefix}q_mlp2", n_units=4 * n_embed, tau_m=0., act_fx="relu",
+        self.q_mlp2_Ratecell = RateCell(f"{prefix}q_mlp2_Ratecell", n_units=4 * n_embed, tau_m=0., act_fx="relu",
                            batch_size= batch_size * seq_len)
-        self.Q_q = StaticSynapse(f"{prefix}Q_q", shape=(n_embed, n_embed), eta=eta,
-                          weight_init=dist.uniform(amin=-0.3, amax=0.3), bias_init=dist.constant(value=0.),
-                          w_bound=0., optim_type=optim_type, sign_value=-1., key=subkeys[6])
+        self.Q_q = StaticSynapse(f"{prefix}Q_q", shape=(n_embed, n_embed),
+                         bias_init=dist.constant(value=0.), key=subkeys[6])
                 
-        self.Q_k = StaticSynapse(f"{prefix}Q_k", shape=(n_embed, n_embed), eta=eta,
-                          weight_init=dist.uniform(amin=-0.3, amax=0.3), bias_init=dist.constant(value=0.),
-                          w_bound=0., optim_type=optim_type, sign_value=-1., key=subkeys[7])
+        self.Q_k = StaticSynapse(f"{prefix}Q_k", shape=(n_embed, n_embed),
+                          bias_init=dist.constant(value=0.), key=subkeys[7])
                 
-        self.Q_v = StaticSynapse(f"{prefix}Q_v", shape=(n_embed, n_embed), eta=eta,
-                          weight_init=dist.uniform(amin=-0.3, amax=0.3), bias_init=dist.constant(value=0.),
-                          w_bound=0., optim_type=optim_type, sign_value=-1., key=subkeys[8])
+        self.Q_v = StaticSynapse(f"{prefix}Q_v", shape=(n_embed, n_embed),
+                          bias_init=dist.constant(value=0.), key=subkeys[8])
         
-        self.q_attn_block = AttentionBlock(f"{prefix}q_attn_block", z_qkv=self.q_qkv, W_q=self.Q_q, W_k=self.Q_k, W_v=self.Q_v,
+        self.q_attn_block = AttentionBlock(f"{prefix}q_attn_block",
+
                                    n_heads=n_heads, n_embed=n_embed, seq_len=seq_len,
                                    dropout_rate=dropout_rate, batch_size=batch_size)
                 
         
-        self.Q_attn_out = StaticSynapse(f"{prefix}Q_attn_out", shape=(n_embed, n_embed), eta=eta,
-                                 weight_init=dist.uniform(amin=-0.3, amax=0.3), bias_init=dist.constant(value=0.),
-                                 w_bound=0., optim_type=optim_type, sign_value=-1., key=subkeys[9])
+        self.Q_attn_out = StaticSynapse(f"{prefix}Q_attn_out", shape=(n_embed, n_embed),
+                                 bias_init=dist.constant(value=0.),
+ key=subkeys[0])
                 
-        self.Q_mlp1 = StaticSynapse(f"{prefix}Q_mlp1", shape=(n_embed, 4 * n_embed), eta=eta,
-                              weight_init=dist.uniform(amin=-0.3, amax=0.3), bias_init=dist.constant(value=0.),
-                              w_bound=0., optim_type=optim_type, sign_value=-1., key=subkeys[10])
+        self.Q_mlp1 = StaticSynapse(f"{prefix}Q_mlp1", shape=(n_embed, 4 * n_embed),
+                             bias_init=dist.constant(value=0.), key=subkeys[0])
                 
-        self.Q_mlp2 = StaticSynapse(f"{prefix}Q_mlp2", shape=(4* n_embed, n_embed), eta=eta,
-                              weight_init=dist.uniform(amin=-0.3, amax=0.3), bias_init=dist.constant(value=0.),
-                              w_bound=0., optim_type=optim_type, sign_value=-1., key=subkeys[11])
+        self.Q_mlp2 = StaticSynapse(f"{prefix}Q_mlp2", shape=(4* n_embed, n_embed),
+                             bias_init=dist.constant(value=0.), key=subkeys[0])
                         
         
         self.reshape_3d_to_2d_proj1= ReshapeComponent(f"{prefix}reshape_3d_to_2d_proj1",

--- a/projection/projection.py
+++ b/projection/projection.py
@@ -1,27 +1,25 @@
-from ngclearn.components import GaussianErrorCell as ErrorCell, RateCell, HebbianSynapse, StaticSynapse
-from ngclearn.utils.weight_distribution import uniform, constant
+from ngclearn.components import GaussianErrorCell as ErrorCell, RateCell, StaticSynapse
 from utils.model_util import ReshapeComponent
-from utils.attention_utils import AttentionBlock
 from utils.embed_utils import EmbeddingSynapse
-import ngclearn.utils.weight_distribution as dist
+from ngclearn.utils.distribution_generator import DistributionGenerator as dist
 from projection.proj_block import ProjBlock
 from jax import random
 class Projection():
     def __init__(self, dkey, n_embed, seq_len, batch_size, vocab_size, eta, optim_type, pos_learnable, wub, wlb, n_blocks, n_heads, dropout_rate,  **kwargs):
         dkey, *subkeys = random.split(dkey, 20)
         
-        self.q_embed = RateCell("q_embed", n_units=seq_len, tau_m=0., act_fx="identity",
+        self.q_embed_Ratecell = RateCell("q_embed_Ratecell", n_units=seq_len, tau_m=0., act_fx="identity",
                             batch_size=batch_size)
         
-        self.q_out = RateCell("q_out", n_units=n_embed, tau_m=0., act_fx="identity",
+        self.q_out_Ratecell = RateCell("q_out_Ratecell", n_units=n_embed, tau_m=0., act_fx="identity",
                           batch_size= batch_size * seq_len)
-        self.q_target = RateCell("q_target", n_units=vocab_size, tau_m=0., act_fx="softmax",
+        self.q_target_Ratecell = RateCell("q_target", n_units=vocab_size, tau_m=0., act_fx="softmax",
                                batch_size=batch_size * seq_len)
                
         self.Q_embed = EmbeddingSynapse("Q_embed", vocab_size=vocab_size, seq_len=seq_len,
                                 embed_dim=n_embed, batch_size= batch_size,
                                 pos_learnable=pos_learnable, eta=eta,
-                                optim_type=optim_type, key=subkeys[5])
+                                 optim_type=optim_type, key=subkeys[5])
                 
         self.blocks=[]
         for k in range(n_blocks):
@@ -39,9 +37,7 @@ class Projection():
                           wlb=wlb)
             self.blocks.append(block)       
         
-        self.Q_out = StaticSynapse("Q_out", shape=(n_embed, vocab_size), eta=eta,
-                             weight_init=dist.uniform(amin=-0.3, amax=0.3), bias_init=dist.constant(value=0.),
-                             w_bound=0., optim_type=optim_type, sign_value=-1., key=subkeys[12])
+        self.Q_out = StaticSynapse("Q_out", shape=(n_embed, vocab_size),  bias_init=dist.constant(value=0.), key=subkeys[12])
                 
         self.eq_target = ErrorCell("eq_target", n_units=vocab_size, batch_size=batch_size * seq_len)
                 

--- a/train.py
+++ b/train.py
@@ -23,7 +23,7 @@ def main():
     
     model = NGCTransformer(dkey, batch_size=batch_size, seq_len=seq_len, n_embed=n_embed, vocab_size=vocab_size, n_layers=n_layers, n_heads=config.n_heads,
                           T=T, dt=1., tau_m=tau_m , act_fx=act_fx, eta=eta, dropout_rate= dropout_rate, exp_dir="exp",
-                  loadDir= None, pos_learnable= pos_learnable, optim_type=optim_type, wub = wub, wlb= wlb, model_name="ngc transformer" )
+                  loadDir= None, pos_learnable= pos_learnable, optim_type=optim_type, wub = wub, wlb= wlb, model_name="ngc_transformer" )
 
     def train_model(data_loader):
         total_nll, total_tokens = 0., 0
@@ -80,7 +80,7 @@ def main():
         dev_ce, dev_ppl = eval_model(model, valid_loader, vocab_size)
         print(f"Iter {i} Summary: CE = {dev_ce:.4f}, PPL = {dev_ppl:.4f}, Avg EFE = {avg_train_EFE:.4f}")
         if  i == (num_iter-1):
-          model.save_to_disk(params_only=True) # save final state of model to disk
+          model.save_to_disk(params_only=False) # save final state of model to disk
 
    
 if __name__ == "__main__":

--- a/utils/model_util.py
+++ b/utils/model_util.py
@@ -1,10 +1,9 @@
-from jax import random, numpy as jnp, jit
-import jax
-from functools import partial
-from ngclearn.utils.optim import get_opt_init_fn, get_opt_step_fn
+from jax import  numpy as jnp
 from ngclearn.components.jaxComponent import JaxComponent
-from ngclearn import resolver, Compartment
-from ngcsimlib.compilers.process import transition
+from ngclearn import Compartment
+from ngclearn import compilable
+
+# from ngcsimlib.compilers.process import transition
 
 
 
@@ -18,12 +17,19 @@ class ReshapeComponent(JaxComponent):
         self.inputs = Compartment(jnp.zeros(input_shape))
         self.outputs = Compartment(jnp.zeros(output_shape))
     
-    @transition(output_compartments=["outputs"])
-    @staticmethod
-    def advance_state(inputs, output_shape):
-        return inputs.reshape(output_shape)
+    @compilable
+    def advance_state(self):
+        inputs=self.inputs.get()
+        output_shape=self.output_shape.get()
+        output=inputs.reshape(output_shape)
+        self.outputs.set(output)
     
-    @transition(output_compartments=["inputs", "outputs"])
-    @staticmethod  
-    def reset(input_shape, output_shape):
-        return jnp.zeros(input_shape), jnp.zeros(output_shape)
+    
+    @compilable
+    def reset(self):
+        input_shape=self.input_shape.get()
+        output_shape=self.output_shape.get()
+        input=jnp.zeros(input_shape)
+        output=jnp.zeros(output_shape)
+        self.inputs.set(input)
+        self.outputs.set(output)


### PR DESCRIPTION


**### 1. Full Model Restoration (load_from_disk)**

Problem: Loading restored only partial state (top-level circuit), leaving embeddings, attention, MLPs, projections, weights, and internal states missing
Fix: Refactored load_from_disk to fully restore the entire model, including:

Embedding & output weights

Projection and reshape modules

All attention/MLP/projection blocks across all layers

Result: Loaded models are now identical to saved models, immediately runnable, scalable with n_layers, and fully reproducible.

**### 2. Evaluation & Training Fixes**

Model naming: "ngc transformer" → "ngc_transformer" (fixes missing context_load.json)

Eval loading: loaddir=None → loaddir="exp" so eval loads trained weights

Weight loading: Removed unnecessary loading of Hebbian, RateCell, StaticSynapses, ErrorCell, and Projection; now weights-only loading via load_weights_into_model

Training save fix: save_to_disk(params_only=False) ensures complete model state is saved

### **3. Constructor Refactor (Safety & Determinism)**

Enforced build-then-load initialization pattern

Reordered parameters: structural args first, optional flags later

Made optional args (loadDir, optim_type) keyword-only

Fixed critical bug: n_layers and n_embed were swapped, causing invalid tensor shapes

Impact: Prevents broken instantiations and argument misalignment

**### 4. Deterministic Loading & Circuit Refactor**

Load timing fix: loadDir logic moved to the end of __init__

Ensures full topology exists before weights load

Prevents deep-layer AttributeErrors

Circuit refactor:

Embedding, blocks, output, and a new top-level Projection module are always constructed

load_from_disk explicitly uses n_layers for deterministic restoration

Result: Fresh-build and load paths now share one consistent architecture

**### 5. Multi-Layer Latent Synchronization**

Bug: Only layer 0 had its latent variables (z_qkv, z_mlp, z_mlp2) synchronized

Fix: Added loop over all layers to synchronize latents from projection blocks

Impact: Correct dynamics and predictions in multi-layer models




### **1 Elimination of Manual Dynamic Mapping & Command Wrapping**
### **A ,Removed manual component loading**
1. Eliminated large get_components(...) string lists
2. Avoided unpacking dozens of circuit elements into self.*
3. Reduced tight coupling between model logic and circuit internals
4. Eliminated explicit block-wise bookkeeping
5. Removed self.block_components and self.nodes aggregation
6. Stopped manually iterating over layers to collect low-level tensors
7. Relied on block/subsystem ownership to manage internal components
8. Promoted processes to first-class attributes
### **B what is changed to**
1. Assigned reset, advance, evolve, project, and embedding_evolve directly
2. Removed repetitive wrap_and_add_command(jit(proc.pure)) calls
3. Made execution intent explicit and easier to test and reuse
4. Removed Context.dynamicCommand with direct methods
5. Converted clamp_input, clamp_target, and clamp_infer_target into plain class methods
6. Improved readability and reduced runtime overhead
###
**2 . Core Architectural & Compiler Compliance (Most Important)**
**Migration to @compilable (Critical)**
- Refactored all dynamic methods (**advance_state**, **evolve**, **reset**) from deprecated **@transition**, **@scanner**, and **@staticmethod** implementations to **instance-based @compilable methods**.
- Removed deprecated import **ngcsimlib.compilers.process.transition**.
- Replaced by
from ngclearn import compilable
**Enables:**
- **Correct JIT compilation**
- **Full compatibility with ngclearn v3 execution model**
### **3 Process function change**
1. The previous code directly accessed the circuit via self.circuit.reset(), self.circuit.advance(), self.circuit.project(), and self.circuit.evolve(), mixing dynamic commands with component access.
2. Replaced all self.circuit.* calls with explicit, top-level process objects (self.reset.run(), self.advance.run(), self.project.run(), self.evolve.run(), self.embedding_evolve.run()).
###
** 4 Explicit State Access via Compartment API**
- Replaced all implicit **.value()** calls with **self.compartment.get()** and **self.compartment.set(...)**.
- Ensures compatibility with the **ngclearn v3 state manager** and prevents hidden state mutation.
### **5 ,Transition from JaxProcess to MethodProcess for Native JIT Compilation**
a. Replaced legacy JaxProcess with MethodProcess for all primary execution loops (advance, evolve, project).
b. Performance: Leverages the ngcsimlib compiler for chained methods, maintaining JAX speed while removing the need for manual wrap_and_add_command logic.
## **6 . Dependency & Utility Modernization**
**Distribution Utility Migration**
**7 Migrated from **ngclearn.utils.weight_distribution** to **ngclearn.utils.distribution_generator** (aliased as **dist**).**
**Import Cleanup**
- Removed **import ngclearn.utils.weight_distribution as dist**.
- Replaced with **import ngclearn.utils.distribution_generator as dist**.
- Functionality moved to the more robust **distribution_generator** module.
**8, Structural Integrity & Wiring Syntax**
a. Standardized Wiring: Migrated to the ngclearn operator overloading syntax (>>) for all circuit connections (e.g., source.output >> target.input).
b. Unconditional Definition: Circuit components are now defined before any loading logic, preventing AttributeErrors and ensuring the topological structure is always memory-resident.
### **9 StaticSynapse Constructor Simplification**
- Removed explicit weight initializers and auxiliary parameters (**eta**, **w_bound**, **optim_type**).
- Delegated responsibility to **default component behavior**.
### 8 **Deterministic Weight Initialization**
- Updated **EmbeddingSynapse** to use a fixed PRNG seed **random.PRNGKey(1234)**.
- Guarantees **reproducible experiments** across runs and environments.
## **10 . Naming, Namespace, and Debugging Improvements**
**Namespace Shadowing Fix**
- Appended **_Ratecell** suffix to all neuron components.
**Examples:**
- **q_qkv → q_qkv_Ratecell**
- **q_embed → q_embed_Ratecell**
**Prefix Convention Standardization**
- Updated component prefixes from **proj_block{id}_** to **block_proj{id}_**.
- Enforces a **consistent and readable naming convention** across modules.
