### PR TITLE
NGC Training Speed Optimization                                                        

### DIFF
--- a/data_preprocess/data_loader.py
+++ b/data_preprocess/data_loader.py
@@ -2,7 +2,7 @@ import jax.numpy as jnp
 from pathlib import Path
 from ngclearn.utils.data_loader import DataLoader as NGCDataLoader
 import sys
-
+import numpy as np
 DIR = Path(__file__).parent
 sys.path.append(str(DIR.parent))
 
@@ -36,12 +36,13 @@ class DataLoader:
                 jnp.full((window_size - len(tokens),), self.pad_token)
             ])
             sequences = padded_tokens.reshape(1, -1)  
-        else:
-            sequences = []
-            for i in range(num_sequences):
-                window = tokens[i:i + window_size]
-                sequences.append(window)
-            sequences = jnp.stack(sequences)  
+        # else:
+        #     sequences = []
+        #     for i in range(num_sequences):
+        #         window = tokens[i:i + window_size]
+        #         sequences.append(window)
+        #     sequences = jnp.stack(sequences)  
+        sequences = np.lib.stride_tricks.sliding_window_view(tokens, window_size)
         
         inputs = sequences[:, :-1]    
         targets = sequences[:, 1:]    

--- a/data_preprocess/data_loader.py
+++ b/data_preprocess/data_loader.py
@@ -36,12 +36,7 @@ class DataLoader:
                 jnp.full((window_size - len(tokens),), self.pad_token)
             ])
             sequences = padded_tokens.reshape(1, -1)  
-        # else:
-        #     sequences = []
-        #     for i in range(num_sequences):
-        #         window = tokens[i:i + window_size]
-        #         sequences.append(window)
-        #     sequences = jnp.stack(sequences)  
+     
         sequences = np.lib.stride_tricks.sliding_window_view(tokens, window_size)
         
         inputs = sequences[:, :-1]    

--- a/train.py
+++ b/train.py
@@ -26,7 +26,7 @@ def main():
     dkey = random.PRNGKey(1234)
     
     data_loader = DataLoader(seq_len=seq_len, batch_size=batch_size)
-    train_loader, valid_loader, test_loader = data_loader.load_and_prepare_data()
+    train_loader, valid_loader, _ = data_loader.load_and_prepare_data()
     
     model = NGCTransformer(dkey, batch_size=batch_size, seq_len=seq_len, n_embed=n_embed, vocab_size=vocab_size, n_layers=n_layers, n_heads=config.n_heads,
                           T=T, dt=1., tau_m=tau_m , act_fx=act_fx, eta=eta, dropout_rate= dropout_rate, exp_dir="exp",
@@ -36,7 +36,7 @@ def main():
         total_nll, total_tokens = 0., 0
         
         for batch in data_loader:
-            inputs = batch[0][1]
+            inputs = batch[0][1].astype(jnp.bfloat16) 
             targets = batch[1][1]
             
             targets_flat = jax.nn.one_hot(targets.flatten(), vocab_size)

--- a/train.py
+++ b/train.py
@@ -7,6 +7,8 @@ from config import Config as config
 from eval import eval_model
 import time
 
+
+jax.config.update("jax_default_matmul_precision", "high")
 def main():
     seq_len, batch_size, n_embed, vocab_size, n_layers, n_heads, n_iter, optim_type = config.seq_len, config.batch_size, config.n_embed, config.vocab_size, config.n_layers, config.n_heads, config.n_iter, config.optim_type
     pos_learnable= config.pos_learnable

--- a/train.py
+++ b/train.py
@@ -9,6 +9,9 @@ import time
 
 
 jax.config.update("jax_default_matmul_precision", "high")
+jax.config.update("jax_compilation_cache_dir", "/tmp/jax_cache")
+jax.config.update("jax_persistent_cache_min_entry_size_bytes", 0)
+jax.config.update("jax_persistent_cache_min_compile_time_secs", 0)
 def main():
     seq_len, batch_size, n_embed, vocab_size, n_layers, n_heads, n_iter, optim_type = config.seq_len, config.batch_size, config.n_embed, config.vocab_size, config.n_layers, config.n_heads, config.n_iter, config.optim_type
     pos_learnable= config.pos_learnable

--- a/train.py
+++ b/train.py
@@ -36,7 +36,7 @@ def main():
         total_nll, total_tokens = 0., 0
         
         for batch in data_loader:
-            inputs = batch[0][1].astype(jnp.bfloat16) 
+            inputs = batch[0][1]
             targets = batch[1][1]
             
             targets_flat = jax.nn.one_hot(targets.flatten(), vocab_size)


### PR DESCRIPTION
This PR introduces optimizations targeting the training pipeline's speed and memory         efficiency.                                                                                           
                                                                                                        
**Changes**                                                                                               
                                                                                                        
**1. Vectorized Sequence Creation via Sliding Window** [d4d5ada
](https://github.com/iCog-Labs-Dev/NGC-PC-Transformers/commit/d4d5ada89e66eabf9776d9fb3b7e2da39cd35ae9)
                                 

- Replaced the Python for-loop in `data_preprocess/data_loader.py` that iterated over tokens one-by-one to build input sequences with `numpy.lib.stride_tricks.sliding_window_view`. The original loop created each window individually and stacked them, which scaled poorly with dataset size. The sliding window view constructs all overlapping windows in a single vectorized operation with zero-copy memory semantics since it returns a view over the original array rather than allocating new memory for each window.

**2. JAX Matmul Precision Configuration**  [939ba04
](https://github.com/iCog-Labs-Dev/NGC-PC-Transformers/commit/939ba044483a9f9db1efd5f364f30c3e6ad8c3f0) 

- Set jax_default_matmul_precision to "high" in `train.py`, which maps to NVIDIA's `TensorFloat-32 (TF32)` on GPU. `TF32` reduces the mantissa from `float32`'s 23 bits down to 10 bits for the multiplication, while keeping the full 8-bit exponent range and accumulating products in full `float32`. This gives roughly 2x matmul throughput compared to full `float32`, while retaining significantly more precision than `bfloat16` (10 mantissa bits vs 8). 

**3. Persistent Compilation Cache**  [0aa3cbb
](https://github.com/iCog-Labs-Dev/NGC-PC-Transformers/commit/0aa3cbb66e49bb702b493e67e5a79c16eb5ab7e0)

Enabled JAX's persistent compilation cache by setting

- `jax_compilation_cache_dir`
- `jax_persistent_cache_min_entry_size_bytes (to 0)`
- `jax_persistent_cache_min_compile_time_secs (to 0)`

JAX recompiles XLA HLO graphs on every program restart by default, which adds significant overhead to the first epoch. With this cache, compiled artifacts are stored to `/tmp/jax_cache `and reused across runs, eliminating redundant recompilation for unchanged graph shapes.
                
                  