### PR TITLE
Refactor model output, training loop, and config usage   

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -6,7 +6,6 @@ from model import NGCTransformer
 from ngclearn.utils.metric_utils import measure_CatNLL
 from data_preprocess.data_loader import DataLoader
 from config import Config as config
-import jax.random as random
 import time
 
 def eval_model(model: NGCTransformer, data_loader, vocab_size: int):
@@ -14,36 +13,26 @@ def eval_model(model: NGCTransformer, data_loader, vocab_size: int):
     Runs inference-only forward pass on a data loader and returns
     cross-entropy and perplexity.
     """
-    start_time = time.time()
     total_nll = 0.0
     total_tokens = 0
-    batch_idx = 0
 
-    for batch in data_loader:
-        inputs = batch[0][1]         
-        targets = batch[1][1]        
+    for batch_idx, batch in enumerate(data_loader):
+        inputs = batch[0][1]
+        targets = batch[1][1]
 
-       
         targets_flat = jax.nn.one_hot(targets.flatten(), vocab_size)
-        yMu_inf, y_mu, _ = model.process(obs=inputs,
-                                      lab=targets_flat,
-                                      adapt_synapses=False)
+        _, y_mu, _ = model.process(obs=inputs,
+                                   lab=targets_flat,
+                                   adapt_synapses=False)
 
-        y_pred = y_mu.reshape(-1, vocab_size)   
-
-        total_nll += measure_CatNLL(y_pred, targets_flat) * targets_flat.shape[0]
+        y_pred = y_mu.reshape(-1, vocab_size)
+        batch_ce_loss = measure_CatNLL(y_pred, targets_flat).mean()
+        total_nll += batch_ce_loss * targets_flat.shape[0]
         total_tokens += targets_flat.shape[0]
-        
+
         if batch_idx % 10 == 0:
-            y_pred = y_mu.reshape(-1, vocab_size)
-            y_true = targets_flat
-            
-            batch_nll = measure_CatNLL(y_pred, y_true)
-            batch_ce_loss = batch_nll.mean()  
             batch_ppl = jnp.exp(batch_ce_loss)
             print(f" Eval Batch {batch_idx}: | CE = {batch_ce_loss:.4f} | PPL = {batch_ppl:.4f}")
-
-        batch_idx += 1
 
     ce = total_nll / total_tokens
     ppl = jnp.exp(ce)
@@ -83,7 +72,7 @@ def load_weights_into_model(model, model_dir):
 
 if __name__ == "__main__":
     
-    dkey = random.PRNGKey(0)
+    dkey = jax.random.PRNGKey(0)
     model = NGCTransformer(
         dkey=dkey,
         batch_size=config.batch_size,

--- a/model.py
+++ b/model.py
@@ -572,7 +572,8 @@ class NGCTransformer:
              
             self.advance.run(t=ts,dt=1.)
            
-        y_mu = self.output.W_out.outputs.get() 
+        # y_mu = self.output.W_out.outputs.get() 
+        y_mu = self.z_actfx.zF.get() 
 
         L1 = self.embedding.e_embed.L.get()
         L4 = self.output.e_out.L.get()

--- a/train.py
+++ b/train.py
@@ -33,58 +33,43 @@ def main():
                   loadDir= None, pos_learnable= pos_learnable, optim_type=optim_type, wub = wub, wlb= wlb, model_name="ngc_transformer" )
 
     def train_model(data_loader):
+        train_EFE = 0.
         total_nll, total_tokens = 0., 0
-        
-        for batch in data_loader:
+
+        for batch_idx, batch in enumerate(data_loader):
             inputs = batch[0][1]
             targets = batch[1][1]
-            
-            targets_flat = jax.nn.one_hot(targets.flatten(), vocab_size)
-            yMu_inf, y_mu, _EFE = model.process(obs=inputs, lab=targets_flat, adapt_synapses=False)
-            
+
+            targets_flat = jax.nn.one_hot(targets, vocab_size).reshape(-1, vocab_size)
+
+            _, y_mu, _EFE = model.process(obs=inputs, lab=targets_flat, adapt_synapses=True)
+            train_EFE += _EFE
+
             y_pred = y_mu.reshape(-1, vocab_size)
-            y_true = targets_flat
-            
-            total_nll += measure_CatNLL(y_pred, y_true) * y_true.shape[0]
-            total_tokens += y_true.shape[0]
-        
+            batch_ce_loss = measure_CatNLL(y_pred, targets_flat).mean()
+            total_nll += batch_ce_loss * targets_flat.shape[0]
+            total_tokens += targets_flat.shape[0]
+
+            if batch_idx % 10 == 0:
+                batch_ppl = jnp.exp(batch_ce_loss)
+                print(f"  Batch {batch_idx}: EFE = {_EFE:.4f}, CE = {batch_ce_loss:.4f}, PPL = {batch_ppl:.4f}")
+
+        num_batches = batch_idx + 1
+        avg_train_EFE = train_EFE / num_batches
         ce_loss = total_nll / total_tokens
-        return ce_loss, jnp.exp(ce_loss)
-    
+        ppl = jnp.exp(ce_loss)
+        return avg_train_EFE, ce_loss, ppl
+
     start_time = time.time()
 
     for i in range(epoch):
-        train_EFE = 0.
-        total_batches = 0
-        
         print(f"\nEpoch {i}:")
-        
-        for batch_idx, batch in enumerate(train_loader):
-            inputs = batch[0][1]
-            targets = batch[1][1]
-            
-            #Convert targets to one-hot and flatten
-            targets_flat = jax.nn.one_hot(targets.flatten(), vocab_size)
-            
-            yMu_inf, y_mu, _EFE = model.process(obs=inputs, lab=targets_flat, adapt_synapses=True)
-            train_EFE += _EFE
-            total_batches += 1
 
-            if batch_idx % 10 == 0:
-                y_pred = y_mu.reshape(-1, vocab_size)
-                y_true = targets_flat
-                
-                batch_nll = measure_CatNLL(y_pred, y_true)
-                batch_ce_loss = batch_nll.mean()  
-                batch_ppl = jnp.exp(batch_ce_loss)
-                
-                print(f"  Batch {batch_idx}: EFE = {_EFE:.4f}, CE = {batch_ce_loss:.4f}, PPL = {batch_ppl:.4f}")
-        
-        avg_train_EFE = train_EFE / total_batches if total_batches > 0 else 0
-        
+        avg_train_EFE, train_ce, train_ppl = train_model(train_loader)
+
         dev_ce, dev_ppl = eval_model(model, valid_loader, vocab_size)
-        print(f"Epoch {i} Summary: CE = {dev_ce:.4f}, PPL = {dev_ppl:.4f}, Avg EFE = {avg_train_EFE:.4f}")
-        if  i == (epoch-1):
+        print(f"Epoch {i} Summary: Train CE = {train_ce:.4f}, Train PPL = {train_ppl:.4f}, Val CE = {dev_ce:.4f}, Val PPL = {dev_ppl:.4f}, Avg EFE = {avg_train_EFE:.4f}")
+        if i == (epoch-1):
           model.save_to_disk(params_only=False) # save final state of model to disk
     total_time = time.time() - start_time
     print(f"\nTraining finished.")

--- a/train.py
+++ b/train.py
@@ -19,7 +19,7 @@ def main():
     wub= config.wub 
     wlb= config.wlb
     eta = config.eta
-    T = config.n_iter
+    T = n_iter
     tau_m= config.tau_m
     act_fx= config.act_fx
     dropout_rate= config.dropout_rate
@@ -28,7 +28,7 @@ def main():
     data_loader = DataLoader(seq_len=seq_len, batch_size=batch_size)
     train_loader, valid_loader, _ = data_loader.load_and_prepare_data()
     
-    model = NGCTransformer(dkey, batch_size=batch_size, seq_len=seq_len, n_embed=n_embed, vocab_size=vocab_size, n_layers=n_layers, n_heads=config.n_heads,
+    model = NGCTransformer(dkey, batch_size=batch_size, seq_len=seq_len, n_embed=n_embed, vocab_size=vocab_size, n_layers=n_layers, n_heads=n_heads,
                           T=T, dt=1., tau_m=tau_m , act_fx=act_fx, eta=eta, dropout_rate= dropout_rate, exp_dir="exp",
                   loadDir= None, pos_learnable= pos_learnable, optim_type=optim_type, wub = wub, wlb= wlb, model_name="ngc_transformer" )
 


### PR DESCRIPTION
**Changes**

 - `train.py`: Extract per-batch training logic into `train_model` helper function.[1da16f8](https://github.com/iCog-Labs-Dev/NGC-PC-Transformers/commit/1da16f889f6924941047b6a70b87da401c9cadd0)
 - `model.py`: Return `y_mu `as post-softmax probabilities with `z_actfx.zF` instead of raw logits from process() to produce valid CE/PPL metrics.[fc7cdd5
](https://github.com/iCog-Labs-Dev/NGC-PC-Transformers/commit/fc7cdd594cb9cd3336ae16ccceadf4f1271ae51b)                                                  
  - `eval.py`: Remove unused variables and duplicate config reads.[235b1bf
](https://github.com/iCog-Labs-Dev/NGC-PC-Transformers/commit/235b1bf1360561a905e28fdaaedea880f4cd3d2e)
  - `train.py`: Use already-unpacked local variables instead of re-reading from
  config. [fe37ea1
](https://github.com/iCog-Labs-Dev/NGC-PC-Transformers/commit/fe37ea11a571150039405db993d5365792d864eb)
