### PR TITLE
Null initialization

### DIFF
--- a/model.py
+++ b/model.py
@@ -348,10 +348,10 @@ class NGCTransformer:
                 reset_process >> self.projection.q_out_Ratecell.reset
                 reset_process >> self.projection.q_target_Ratecell.reset
                 reset_process >> self.projection.eq_target.reset
-                # reset_process >> self.embedding.z_embed.reset
+                reset_process >> self.embedding.z_embed.reset
                 # reset_process >> self.output.z_out.reset
-                # reset_process >> self.z_target.reset
-                # reset_process >> self.z_actfx.reset
+                reset_process >> self.z_target.reset
+                reset_process >> self.z_actfx.reset
                 reset_process >> self.embedding.e_embed.reset
                 reset_process >> self.output.e_out.reset
                 reset_process >> self.output.W_out.reset

--- a/model.py
+++ b/model.py
@@ -314,12 +314,12 @@ class NGCTransformer:
                    
                    
                    
-                    reset_process >> block.attention.z_qkv.reset
-                    reset_process >> block.attention.z_attn.reset
+                    # reset_process >> block.attention.z_qkv.reset
+                    # reset_process >> block.attention.z_attn.reset
                     reset_process >> block.attention.e_qkv.reset
                     reset_process >> block.attention.e_attn.reset
-                    reset_process >> block.mlp.z_mlp.reset
-                    reset_process >> block.mlp.z_mlp2.reset
+                    # reset_process >> block.mlp.z_mlp.reset
+                    # reset_process >> block.mlp.z_mlp2.reset
                     reset_process >> block.mlp.e_mlp.reset
                     reset_process >> block.mlp.e_mlp1.reset
                     reset_process >> block.reshape_3d_to_2d.reset
@@ -348,10 +348,10 @@ class NGCTransformer:
                 reset_process >> self.projection.q_out_Ratecell.reset
                 reset_process >> self.projection.q_target_Ratecell.reset
                 reset_process >> self.projection.eq_target.reset
-                reset_process >> self.embedding.z_embed.reset
-                reset_process >> self.output.z_out.reset
-                reset_process >> self.z_target.reset
-                reset_process >> self.z_actfx.reset
+                # reset_process >> self.embedding.z_embed.reset
+                # reset_process >> self.output.z_out.reset
+                # reset_process >> self.z_target.reset
+                # reset_process >> self.z_actfx.reset
                 reset_process >> self.embedding.e_embed.reset
                 reset_process >> self.output.e_out.reset
                 reset_process >> self.output.W_out.reset

--- a/tuning.py
+++ b/tuning.py
@@ -25,7 +25,7 @@ from config import Config as base_config
 from ngclearn.utils.metric_utils import measure_CatNLL
 import gc
 
-EFE_STABILITY_THRESHOLD = 2e1
+EFE_STABILITY_THRESHOLD = 300
 
 
 def define_search_space(trial):


### PR DESCRIPTION
This pull request makes targeted adjustments to the model's reset process and tuning parameters. The main changes involve commenting out certain reset steps for model components, likely to improve stability or avoid unnecessary resets, and updating a stability threshold constant used in tuning.

**Model reset process adjustments:**
* Commented out reset steps for `z_qkv`, `z_attn` in `block.attention` and `z_mlp`, `z_mlp2` in `block.mlp` within the model initialization, possibly to prevent redundant or problematic resets.
* Commented out the reset step for `self.output.z_out` in the model initialization.

**Tuning parameter update:**
* Increased the `EFE_STABILITY_THRESHOLD` constant in `tuning.py` from 20 to 300, which likely affects the criteria for model stability during tuning.