### PR TITLE
feat: implement RandomInit class for NGC-compatible random state init…

### DIFF
--- a/model.py
+++ b/model.py
@@ -16,6 +16,7 @@ from layers.output import Output
 from utils.model_util import ReshapeComponent, Outgrad
 from projection.projection import Projection
 import numpy as np
+from utils.random_init import RandomInit
 
 
 
@@ -78,6 +79,7 @@ class NGCTransformer:
                 
             self.z_target=RateCell("z_target", n_units= self.vocab_size, tau_m=0., act_fx="identity", batch_size=self.batch_size * self.seq_len) 
             self.z_actfx= RateCell("z_actfx", n_units= self.vocab_size, tau_m=tau_m, act_fx="softmax", batch_size=self.batch_size * self.seq_len)
+            self.random_init = RandomInit("random_init", batch_size=self.batch_size * self.seq_len,n_embed=self.n_embed)
             self.projection = Projection(dkey=subkeys[29], n_embed=self.n_embed, seq_len=self.seq_len, batch_size=self.batch_size,
                                              vocab_size=self.vocab_size, eta=eta, optim_type=optim_type, pos_learnable=pos_learnable, wub=wub, wlb=wlb, n_blocks=n_layers, n_heads=n_heads, dropout_rate=dropout_rate)
             self.reshape_4d_to_2d = ReshapeComponent("reshape_4d_to_2d",
@@ -543,9 +545,12 @@ class NGCTransformer:
         for i in range(self.n_layers):
         #     block_proj= self.projection.blocks[i]   
             b= self.blocks[i]
-        #     b.attention.z_qkv.z.set(block_proj.q_qkv_Ratecell.z.get())
-        #     b.mlp.z_mlp.z.set(block_proj.q_mlp_Ratecell.z.get())
-        #     b.mlp.z_mlp2.z.set(block_proj.q_mlp2_Ratecell.z.get())
+            self.random_init.advance_state()
+            b.attention.z_qkv.z.set(self.random_init.z_qkv.get())
+            b.attention.z_attn.z.set(self.random_init.z_attn.get())
+            b.mlp.z_mlp.z.set(self.random_init.z_mlp.get())
+            b.mlp.z_mlp2.z.set(self.random_init.z_mlp2.get())
+        
             b.attention.E_q.weights.set(jnp.transpose(b.attention.W_q.weights.get()))
             b.attention.E_k.weights.set(jnp.transpose(b.attention.W_k.weights.get()))
             b.attention.E_v.weights.set(jnp.transpose(b.attention.W_v.weights.get()))
@@ -554,7 +559,7 @@ class NGCTransformer:
             b.mlp.E_mlp1.weights.set(jnp.transpose(b.mlp.W_mlp1.weights.get()))
        
         self.output.E_out.weights.set(jnp.transpose(self.output.W_out.weights.get()))
-        # self.output.z_out.z.set(self.projection.q_out_Ratecell.z.get())
+        self.output.z_out.z.set(self.random_init.z_out.get())
         # self.output.e_out.dmu.set(self.projection.eq_target.dmu.get())
         # self.output.e_out.dtarget.set(self.projection.eq_target.dtarget.get())
         

--- a/utils/random_init.py
+++ b/utils/random_init.py
@@ -1,0 +1,49 @@
+from jax import random
+import jax.numpy as jnp
+from ngclearn.components.jaxComponent import JaxComponent
+from ngclearn import Compartment
+from ngclearn import compilable
+
+
+class RandomInit(JaxComponent):
+    """NGC-compatible random state initializer for latent z tensors.
+    
+    Generates fresh random values each time advance_state() is called.
+    Access the compartments directly:
+    - z_qkv: shape (batch_size, n_embed)
+    - z_attn: shape (batch_size, n_embed)
+    - z_mlp: shape (batch_size, n_embed)
+    - z_out: shape (batch_size, n_embed)
+    - z_mlp2: shape (batch_size, 4 * n_embed)
+    """
+
+
+    def __init__(self, name, batch_size, n_embed, scale=1e-3, key=None, **kwargs):
+        super().__init__(name, **kwargs)
+        self.batch_size = batch_size
+        self.n_embed = n_embed
+        self.scale = scale
+        self.key = Compartment(random.PRNGKey(0) if key is None else key)
+        self.z_qkv = Compartment(jnp.zeros((batch_size, n_embed)))
+        self.z_attn = Compartment(jnp.zeros((batch_size, n_embed)))
+        self.z_mlp = Compartment(jnp.zeros((batch_size, n_embed)))
+        self.z_out = Compartment(jnp.zeros((batch_size, n_embed)))
+        self.z_mlp2 = Compartment(jnp.zeros((batch_size, 4 * n_embed)))
+
+
+    @compilable
+    def advance_state(self):
+        """Generate fresh random values for all latent compartments."""
+        key = self.key.get()
+        k1, k2, k3, k4, k5, next_key = random.split(key, 6)
+        z_qkv = random.normal(k1, (self.batch_size, self.n_embed)) * self.scale
+        z_attn = random.normal(k2, (self.batch_size, self.n_embed)) * self.scale
+        z_mlp = random.normal(k3, (self.batch_size, self.n_embed)) * self.scale
+        z_out = random.normal(k4, (self.batch_size, self.n_embed)) * self.scale
+        z_mlp2 = random.normal(k5, (self.batch_size, 4 * self.n_embed)) * self.scale
+        self.key.set(next_key)
+        self.z_qkv.set(z_qkv)
+        self.z_attn.set(z_attn)
+        self.z_mlp.set(z_mlp)
+        self.z_out.set(z_out)
+        self.z_mlp2.set(z_mlp2)


### PR DESCRIPTION
This pull request introduces a new `RandomInit` component to handle random initialization of latent state tensors in the model, and integrates it into the model's processing flow. The main goal is to generate fresh random latent states for various submodules at each processing step, improving modularity and clarity.

**Integration of random latent state initialization:**

* Added a new `RandomInit` component (`utils/random_init.py`) that generates random latent tensors for attention and MLP submodules, as well as the output layer, with a dedicated `advance_state()` method to refresh these values on demand.
* Integrated `RandomInit` into the model's initialization (`model.py`), creating an instance as `self.random_init` for use during processing.
* Updated the model's `process` method to call `self.random_init.advance_state()` and assign its random latent values to the appropriate submodule compartments (`z_qkv`, `z_attn`, `z_mlp`, `z_mlp2`, and `z_out`) each have different random initialization and at each layer and for the output. [[1]](diffhunk://#diff-fada037ad086638e65c7ae77e3d223963e9afaa26326aab0ea718f4013176e43L546-R553) [[2]](diffhunk://#diff-fada037ad086638e65c7ae77e3d223963e9afaa26326aab0ea718f4013176e43L557-R562)

**Dependency and import updates:**

* Imported `RandomInit` in `model.py` to enable its usage in the model.