### PR TITLE
 Fix generation conditioning and load trained weights for inference

### DIFF
--- a/config.py
+++ b/config.py
@@ -11,7 +11,7 @@ class Config:
     exp_dir = "exp" 
     pos_learnable = True
     optim_type = "sgd"
-    epoch = 1
+    epoch = 20
     n_iter= 26
     # Approximate Xavier scaling: 1 / sqrt(512) is about 0.04
     wub = 0.035284728580901155

--- a/config.py
+++ b/config.py
@@ -11,7 +11,7 @@ class Config:
     exp_dir = "exp" 
     pos_learnable = True
     optim_type = "sgd"
-    epoch = 20
+    epoch = 1
     n_iter= 26
     # Approximate Xavier scaling: 1 / sqrt(512) is about 0.04
     wub = 0.035284728580901155

--- a/generation.py
+++ b/generation.py
@@ -16,7 +16,6 @@ import textwrap
 def generate_text(
     model,
     tokenizer,
-    prompt: str,
     max_new_tokens: int = 100,
     seq_len: int = config.seq_len,
     temperature: float = 1.0,
@@ -28,23 +27,23 @@ def generate_text(
     Generate text using the model and provided tokenizer.
     Works with both custom BPE and tiktoken backends.
     """
-    # Encode prompt - returns jnp.ndarray for both backends
-    prompt_ids = tokenizer.encode(prompt)
-    
-    # Ensure batch dimension: (1, sequence_length)
-    if prompt_ids.ndim == 1:
-        prompt_tensor = prompt_ids[None, :]
-    else:
-        prompt_tensor = prompt_ids
-
-    current_tokens = prompt_tensor
-    current_key = key
-
     if pad_token_id is None:
         if isinstance(tokenizer, BPETokenizer) and tokenizer.tokenizer is not None:
             pad_token_id = tokenizer.tokenizer.token_to_id("<pad>")
+        elif hasattr(tokenizer, "_enc") and hasattr(tokenizer._enc, "eot_token"):
+            pad_token_id = tokenizer._enc.eot_token
         else:
             pad_token_id = 0
+
+    start_token_id = None
+    if isinstance(tokenizer, BPETokenizer) and tokenizer.tokenizer is not None:
+        start_token_id = tokenizer.tokenizer.token_to_id("<bos>")
+    if start_token_id is None:
+        start_token_id = pad_token_id
+
+    # Initialize sequence with start token ID
+    current_tokens = jnp.array([[start_token_id]], dtype=jnp.int32)
+    current_key = key
 
     for _ in range(max_new_tokens):
         # Truncate context to fit model's seq_len
@@ -145,74 +144,14 @@ if __name__ == "__main__":
                 "BPE tokenizer not trained or loaded!\n\n"
             )
 
-    prompt_1 = (
-        "First Citizen:\n"
-        "Before we proceed any further, hear me speak.\n\n"
-        "All:\n"
-        "Speak, speak.\n\n"
-        "First Citizen:\n"
-        "You are all resolved rather to die than to famish?\n\n"
-        "All:\n"
-        "Resolved. resolved.\n\n"
-        "First Citizen:\n"
-        "First, you know Caius Marcius is chief enemy to the people.\n\n"
-        "All:\n"
-        "We know't, we know't."
-    )
-
-    prompt_2 = (
-        "First Soldier:\n"
-        "Fool-hardiness; not I.\n\n"
-        "Second Soldier:\n"
-        "Nor I.\n\n"
-        "First Soldier:\n"
-        "See, they have shut him in.\n\n"
-        "All:\n"
-        "To the pot, I warrant him.\n\n"
-        "LARTIUS:\n"
-        "What is become of Marcius?\n\n"
-        "All:\n"
-        "Slain, sir, doubtless.\n\n"
-        "First Soldier:\n"
-        "Following the fliers at the very heels,\n"
-        "With them he enters; who, upon the sudden,\n"
-        "Clapp'd to their gates: he is himself alone,\n"
-        "To answer all the city.\n\n"
-        "LARTIUS:\n"
-        "O noble fellow!\n"
-        "Who sensibly outdares his senseless sword,\n"
-        "And, when it bows, stands up. Thou art left, Marcius:\n"
-        "A carbuncle entire, as big as thou art,\n"
-        "Were not so rich a jewel. Thou wast a soldier\n"
-        "Even to Cato's wish, not fierce and terrible\n"
-        "Only in strokes; but, with thy grim looks and\n"
-        "The thunder-like percussion of thy sounds,\n"
-        "Thou madst thine enemies shake, as if the world\n"
-        "Were feverous and did tremble.\n\n"
-        "First Soldier:\n"
-        "Look, sir.\n\n"
-        "LARTIUS:\n"
-        "O,'tis Marcius!\n"
-        "Let's fetch him off, or make remain alike.\n\n"
-        "First Roman:\n"
-        "This will I carry to Rome.\n\n"
-        "Second Roman:\n"
-        "And I this.\n\n"
-        "Third Roman:\n"
-        "A murrain on't! I took this for silver."
-    )
-
     rng = jax.random.PRNGKey(0)
     rng, key_1 = jax.random.split(rng)
     rng, key_2 = jax.random.split(rng)
 
-    print("\n**************** PROMPT 1 ****************")
-    print(prompt_1)
     print("\nFINAL GENERATED 1:\n")
     generated_1 = generate_text(
         model,
         tokenizer,
-        prompt_1,
         max_new_tokens=100,
         temperature=0.9,
         top_k=50,
@@ -220,13 +159,10 @@ if __name__ == "__main__":
     )
     print(generated_1)
 
-    print("\n**************** PROMPT 2 ****************")
-    print(prompt_2)
     print("\nFINAL GENERATED 2:\n")
     generated_2 = generate_text(
         model,
         tokenizer,
-        prompt_2,
         max_new_tokens=100,
         temperature=0.9,
         top_k=50,

--- a/generation.py
+++ b/generation.py
@@ -6,52 +6,11 @@ from config import Config as config
 from data_preprocess.data_loader import DataLoader
 from data_preprocess.tokenizer import get_tokenizer, BPETokenizer
 from pathlib import Path
+import re
+import textwrap
 
 
-# Initialize the model
-dkey = jax.random.PRNGKey(0)
-model = NGCTransformer(
-    dkey, 
-    batch_size=config.batch_size, 
-    seq_len=config.seq_len, 
-    n_embed=config.n_embed, 
-    vocab_size=config.vocab_size, 
-    n_layers=config.n_layers, 
-    n_heads=config.n_heads,
-    T=config.n_iter, 
-    dt=1., 
-    tau_m=config.tau_m, 
-    act_fx=config.act_fx, 
-    eta=config.eta, 
-    dropout_rate=config.dropout_rate, 
-    exp_dir="exp",
-    loadDir="exp", 
-    pos_learnable=config.pos_learnable, 
-    optim_type=config.optim_type, 
-    wub=config.wub, 
-    wlb=config.wlb, 
-    model_name="ngc_transformer"
-)
 
-
-tokenizer = get_tokenizer(config)
-
-if isinstance(tokenizer, BPETokenizer) and tokenizer.tokenizer is None:
-    vocab_file = getattr(config, "tokenizer_vocab_file", None)
-    if vocab_file is None:
-        default_path = Path(__file__).parent / "data_preprocess" / "outputs" / "tokenizer" / "bpe_tokenizer.json"
-        if default_path.exists():
-            vocab_file = str(default_path)
-            print(f"Auto-loading BPE tokenizer from default path: {vocab_file}")
-    
-    # Attempt to load
-    if vocab_file and Path(vocab_file).exists():
-        tokenizer.load_tokenizer(vocab_file)
-        print(f"Loaded BPE tokenizer (vocab size: {tokenizer.get_vocab_size()})")
-    else:
-        raise RuntimeError(
-            "BPE tokenizer not trained or loaded!\n\n"
-        )
 
 
 def generate_text(
@@ -59,9 +18,11 @@ def generate_text(
     tokenizer,
     prompt: str,
     max_new_tokens: int = 100,
-    seq_len: int = 8,
+    seq_len: int = config.seq_len,
     temperature: float = 1.0,
-    key=None
+    top_k: int = 0,
+    key=None,
+    pad_token_id: int = None
 ):
     """
     Generate text using the model and provided tokenizer.
@@ -79,35 +40,52 @@ def generate_text(
     current_tokens = prompt_tensor
     current_key = key
 
+    if pad_token_id is None:
+        if isinstance(tokenizer, BPETokenizer) and tokenizer.tokenizer is not None:
+            pad_token_id = tokenizer.tokenizer.token_to_id("<pad>")
+        else:
+            pad_token_id = 0
+
     for _ in range(max_new_tokens):
         # Truncate context to fit model's seq_len
-        if current_tokens.shape[1] > seq_len:
-            input_seq = current_tokens[:, -seq_len:]
+        if current_tokens.shape[1] > config.seq_len:
+            input_seq = current_tokens[:, -config.seq_len:]
         else:
             input_seq = current_tokens
 
-        # Pad to exactly seq_len if needed (assumes token ID 0 = padding)
-        if input_seq.shape[1] < seq_len:
-            pad_len = seq_len - input_seq.shape[1]
-            input_seq = jnp.pad(input_seq, ((0, 0), (0, pad_len)), constant_values=0)
+        # Pad to exactly seq_len if needed
+        if input_seq.shape[1] < config.seq_len:
+            pad_len = config.seq_len - input_seq.shape[1]
+            input_seq = jnp.pad(input_seq, ((0, 0), (0, pad_len)), constant_values=pad_token_id)
         
-        # Dummy target for inference (unused when adapt_synapses=False)
-        dummy_target = jnp.zeros((config.batch_size * config.seq_len, config.vocab_size))  
+        # Forward pass (no target clamping during inference)
+        dummy_target = jnp.zeros((config.batch_size * config.seq_len, config.vocab_size))
 
         # Forward pass
+
         y_mu_inf, y_mu, _ = model.process(input_seq, dummy_target, adapt_synapses=False)
-        logits = y_mu.reshape(config.batch_size, config.seq_len, config.vocab_size)
+        logits = y_mu_inf.reshape(config.batch_size, config.seq_len, config.vocab_size)
 
         # Get logits for the last *real* token (excluding padding)
-        actual_len = min(current_tokens.shape[1], seq_len)
-        last_pos = actual_len - 1
+        if current_tokens.shape[1] > config.seq_len:
+            last_pos = config.seq_len - 1
+        else:
+            last_pos = current_tokens.shape[1] - 1
         next_logits = logits[0, last_pos, :] / temperature
 
         # Sample or take argmax
         if current_key is not None:
-            probs = jax.nn.softmax(next_logits)
-            current_key, subkey = jax.random.split(current_key)
-            next_token = jax.random.choice(subkey, a=config.vocab_size, p=probs)
+            if top_k is not None and top_k > 0:
+                top_k = min(top_k, config.vocab_size)
+                top_vals, top_idx = jax.lax.top_k(next_logits, k=top_k)
+                probs = jax.nn.softmax(top_vals)
+                current_key, subkey = jax.random.split(current_key)
+                choice = jax.random.choice(subkey, a=top_k, p=probs)
+                next_token = top_idx[choice]
+            else:
+                probs = jax.nn.softmax(next_logits)
+                current_key, subkey = jax.random.split(current_key)
+                next_token = jax.random.choice(subkey, a=config.vocab_size, p=probs)
         else:
             next_token = jnp.argmax(next_logits)
 
@@ -119,16 +97,139 @@ def generate_text(
     return tokenizer.decode(generated_ids)
 
 
-# Example usage
+# Initialize the model and tokenizer only when run as a script
 if __name__ == "__main__":
-    prompt = "The king said: "
-    generated = generate_text(
-        model=model,
-        tokenizer=tokenizer,
-        prompt=prompt,
-        max_new_tokens=200,
-        seq_len=config.seq_len,        
-        temperature=0.8,
-        key=jax.random.PRNGKey(42)  
+    # Initialize the model
+    dkey = jax.random.PRNGKey(0)
+    model = NGCTransformer(
+        dkey, 
+        batch_size=config.batch_size,
+        seq_len=config.seq_len, 
+        n_embed=config.n_embed, 
+        vocab_size=config.vocab_size, 
+        n_layers=config.n_layers, 
+        n_heads=config.n_heads,
+        T=config.n_iter, 
+        dt=1., 
+        tau_m=config.tau_m, 
+        act_fx=config.act_fx, 
+        eta=config.eta, 
+        dropout_rate=config.dropout_rate, 
+        exp_dir="exp",
+        loadDir="exp", # Ensure model is loaded from trained exp/ directory
+        pos_learnable=config.pos_learnable, 
+        optim_type=config.optim_type, 
+        wub=config.wub, 
+        wlb=config.wlb, 
+        model_name="ngc_transformer"
     )
-    print(generated)
+
+    # Optional: add custom weight stats here if needed
+
+    tokenizer = get_tokenizer(config)
+
+    if isinstance(tokenizer, BPETokenizer) and tokenizer.tokenizer is None:
+        vocab_file = getattr(config, "tokenizer_vocab_file", None)
+        if vocab_file is None:
+            default_path = Path(__file__).parent / "data_preprocess" / "outputs" / "tokenizer" / "bpe_tokenizer.json"
+            if default_path.exists():
+                vocab_file = str(default_path)
+                print(f"Auto-loading BPE tokenizer from default path: {vocab_file}")
+
+        # Attempt to load
+        if vocab_file and Path(vocab_file).exists():
+            tokenizer.load_tokenizer(vocab_file)
+            print(f"Loaded BPE tokenizer (vocab size: {tokenizer.get_vocab_size()})")
+        else:
+            raise RuntimeError(
+                "BPE tokenizer not trained or loaded!\n\n"
+            )
+
+    prompt_1 = (
+        "First Citizen:\n"
+        "Before we proceed any further, hear me speak.\n\n"
+        "All:\n"
+        "Speak, speak.\n\n"
+        "First Citizen:\n"
+        "You are all resolved rather to die than to famish?\n\n"
+        "All:\n"
+        "Resolved. resolved.\n\n"
+        "First Citizen:\n"
+        "First, you know Caius Marcius is chief enemy to the people.\n\n"
+        "All:\n"
+        "We know't, we know't."
+    )
+
+    prompt_2 = (
+        "First Soldier:\n"
+        "Fool-hardiness; not I.\n\n"
+        "Second Soldier:\n"
+        "Nor I.\n\n"
+        "First Soldier:\n"
+        "See, they have shut him in.\n\n"
+        "All:\n"
+        "To the pot, I warrant him.\n\n"
+        "LARTIUS:\n"
+        "What is become of Marcius?\n\n"
+        "All:\n"
+        "Slain, sir, doubtless.\n\n"
+        "First Soldier:\n"
+        "Following the fliers at the very heels,\n"
+        "With them he enters; who, upon the sudden,\n"
+        "Clapp'd to their gates: he is himself alone,\n"
+        "To answer all the city.\n\n"
+        "LARTIUS:\n"
+        "O noble fellow!\n"
+        "Who sensibly outdares his senseless sword,\n"
+        "And, when it bows, stands up. Thou art left, Marcius:\n"
+        "A carbuncle entire, as big as thou art,\n"
+        "Were not so rich a jewel. Thou wast a soldier\n"
+        "Even to Cato's wish, not fierce and terrible\n"
+        "Only in strokes; but, with thy grim looks and\n"
+        "The thunder-like percussion of thy sounds,\n"
+        "Thou madst thine enemies shake, as if the world\n"
+        "Were feverous and did tremble.\n\n"
+        "First Soldier:\n"
+        "Look, sir.\n\n"
+        "LARTIUS:\n"
+        "O,'tis Marcius!\n"
+        "Let's fetch him off, or make remain alike.\n\n"
+        "First Roman:\n"
+        "This will I carry to Rome.\n\n"
+        "Second Roman:\n"
+        "And I this.\n\n"
+        "Third Roman:\n"
+        "A murrain on't! I took this for silver."
+    )
+
+    rng = jax.random.PRNGKey(0)
+    rng, key_1 = jax.random.split(rng)
+    rng, key_2 = jax.random.split(rng)
+
+    print("\n**************** PROMPT 1 ****************")
+    print(prompt_1)
+    print("\nFINAL GENERATED 1:\n")
+    generated_1 = generate_text(
+        model,
+        tokenizer,
+        prompt_1,
+        max_new_tokens=100,
+        temperature=0.9,
+        top_k=50,
+        key=key_1,
+    )
+    print(generated_1)
+
+    print("\n**************** PROMPT 2 ****************")
+    print(prompt_2)
+    print("\nFINAL GENERATED 2:\n")
+    generated_2 = generate_text(
+        model,
+        tokenizer,
+        prompt_2,
+        max_new_tokens=100,
+        temperature=0.9,
+        top_k=50,
+        key=key_2,
+    )
+    print(generated_2)

--- a/generation.py
+++ b/generation.py
@@ -159,13 +159,4 @@ if __name__ == "__main__":
     )
     print(generated_1)
 
-    print("\nFINAL GENERATED 2:\n")
-    generated_2 = generate_text(
-        model,
-        tokenizer,
-        max_new_tokens=100,
-        temperature=0.9,
-        top_k=50,
-        key=key_2,
-    )
-    print(generated_2)
+    

--- a/model.py
+++ b/model.py
@@ -3,7 +3,7 @@ import jax
 from ngclearn import Context, MethodProcess
 from ngclearn.utils.io_utils import makedir
 from jax import numpy as jnp, random, jit
-from ngclearn.components import HebbianSynapse, StaticSynapse
+from ngclearn.components import GaussianErrorCell as ErrorCell, RateCell, HebbianSynapse, StaticSynapse
 from ngclearn.utils.distribution_generator import DistributionGenerator as dist
 from config import Config as config
 from layers.embedding import EMBEDDING
@@ -16,8 +16,6 @@ from layers.output import Output
 from utils.model_util import ReshapeComponent, Outgrad
 from projection.projection import Projection
 import numpy as np
-from utils.errorcell import GaussianErrorCell as ErrorCell
-from utils.ratecell import RateCell
 
 
 
@@ -209,7 +207,8 @@ class NGCTransformer:
                 self.z_actfx.zF >> self.output.e_out.mu
                 self.z_target.z >> self.output.e_out.target
 
-                self.output.e_out.dtarget >> self.output.E_out.inputs
+                self.output.e_out.dmu >> self.Outgrad.dmu
+                self.Outgrad.dmu_ >> self.output.E_out.inputs
 
 
                 self.output.E_out.outputs >> self.output.z_out.j
@@ -221,7 +220,7 @@ class NGCTransformer:
 
 
                 self.output.z_out.zF >> self.output.W_out.pre
-                self.output.e_out.dtarget >> self.output.W_out.post
+                self.Outgrad.dmu_ >> self.output.W_out.post
 
                         
                         
@@ -503,8 +502,6 @@ class NGCTransformer:
             
             block_proj.reshape_3d_to_2d_proj1.outputs.set(self.circuit.get_components(f"{p_prefix}_reshape_3d_to_2d_proj1").outputs.get())
             block_proj.q_attn_block = self.circuit.get_components(f"{p_prefix}_q_attn_block")
-          
-
     def process(self, obs, lab, adapt_synapses=True):
         
         self.reset.run()
@@ -584,7 +581,7 @@ class NGCTransformer:
                 block = self.blocks[i]
                 block_errors += block.attention.e_attn.L.get() + block.mlp.e_mlp.L.get() + block.mlp.e_mlp1.L.get()
 
-        EFE = block_errors + L1
+        EFE = L4+  block_errors + L1
 
         if adapt_synapses == True:
                 self.embedding_evolve.run()
@@ -595,4 +592,6 @@ class NGCTransformer:
 
     def get_latents(self):
         return self.projection.q_out_Ratecell.z.get()
-  
+        
+
+    

--- a/model.py
+++ b/model.py
@@ -3,7 +3,7 @@ import jax
 from ngclearn import Context, MethodProcess
 from ngclearn.utils.io_utils import makedir
 from jax import numpy as jnp, random, jit
-from ngclearn.components import GaussianErrorCell as ErrorCell, RateCell, HebbianSynapse, StaticSynapse
+from ngclearn.components import HebbianSynapse, StaticSynapse
 from ngclearn.utils.distribution_generator import DistributionGenerator as dist
 from config import Config as config
 from layers.embedding import EMBEDDING
@@ -16,6 +16,8 @@ from layers.output import Output
 from utils.model_util import ReshapeComponent, Outgrad
 from projection.projection import Projection
 import numpy as np
+from utils.errorcell import GaussianErrorCell as ErrorCell
+from utils.ratecell import RateCell
 
 
 
@@ -207,8 +209,7 @@ class NGCTransformer:
                 self.z_actfx.zF >> self.output.e_out.mu
                 self.z_target.z >> self.output.e_out.target
 
-                self.output.e_out.dmu >> self.Outgrad.dmu
-                self.Outgrad.dmu_ >> self.output.E_out.inputs
+                self.output.e_out.dtarget >> self.output.E_out.inputs
 
 
                 self.output.E_out.outputs >> self.output.z_out.j
@@ -220,7 +221,7 @@ class NGCTransformer:
 
 
                 self.output.z_out.zF >> self.output.W_out.pre
-                self.Outgrad.dmu_ >> self.output.W_out.post
+                self.output.e_out.dtarget >> self.output.W_out.post
 
                         
                         
@@ -486,8 +487,8 @@ class NGCTransformer:
             block.mlp.e_mlp.L.set(self.circuit.get_components(f"{b_prefix}_e_mlp").L.get())
             block.mlp.e_mlp1.L.set(self.circuit.get_components(f"{b_prefix}_e_mlp1").L.get())
             # --- Map MLP Sub-block ---
-            block.mlp.z_mlp.z.set(   self.circuit.get_components(f"{b_prefix}_z_mlp"))
-            block.mlp.z_mlp2.z.set(  self.circuit.get_components(f"{b_prefix}_z_mlp2"))
+            block.mlp.z_mlp.z.set(   self.circuit.get_components(f"{b_prefix}_z_mlp").z.get())
+            block.mlp.z_mlp2.z.set(  self.circuit.get_components(f"{b_prefix}_z_mlp2").z.get())
             block.mlp.W_mlp1.weights.set(self.circuit.get_components(f"{b_prefix}_W_mlp1").weights.get())
             block.mlp.W_mlp2.weights.set(self.circuit.get_components(f"{b_prefix}_W_mlp2").weights.get())
             block.mlp.W_mlp1.biases.set(self.circuit.get_components(f"{b_prefix}_W_mlp1").biases.get())
@@ -507,45 +508,45 @@ class NGCTransformer:
     def process(self, obs, lab, adapt_synapses=True):
         
         self.reset.run()
-        # self.projection.Q_embed.word_weights.set(self.embedding.W_embed.word_weights.get())
-        # if self.embedding.W_embed.pos_learnable:
-        #    self.projection.Q_embed.pos_weights.set(self.embedding.W_embed.pos_weights.get())
-        # for i in range(self.n_layers):
-        #     block_proj= self.projection.blocks[i]
-        #     block= self.blocks[i] 
-        #     block_proj.Q_q.weights.set(block.attention.W_q.weights.get())
-        #     block_proj.Q_q.biases.set(block.attention.W_q.biases.get())
-        #     block_proj.Q_k.weights.set(block.attention.W_k.weights.get())
-        #     block_proj.Q_k.biases.set(block.attention.W_k.biases.get())
-        #     block_proj.Q_v.weights.set(block.attention.W_v.weights.get())
-        #     block_proj.Q_v.biases.set(block.attention.W_v.biases.get())
-        #     block_proj.Q_attn_out.weights.set(block.attention.W_attn_out.weights.get())
-        #     block_proj.q_attn_block.inputs_q.set(block.attention.attn_block.inputs_q.get())
-        #     block_proj.q_attn_block.inputs_k.set(block.attention.attn_block.inputs_k.get())
-        #     block_proj.q_attn_block.inputs_v.set(block.attention.attn_block.inputs_v.get())
-        #     block_proj.Q_attn_out.biases.set(block.attention.W_attn_out.biases.get())
-        #     block_proj.Q_mlp1.weights.set(block.mlp.W_mlp1.weights.get())
-        #     block_proj.Q_mlp1.biases.set(block.mlp.W_mlp1.biases.get())
-        #     block_proj.Q_mlp2.weights.set(block.mlp.W_mlp2.weights.get())
-        #     block_proj.Q_mlp2.biases.set(block.mlp.W_mlp2.biases.get())
+        self.projection.Q_embed.word_weights.set(self.embedding.W_embed.word_weights.get())
+        if self.embedding.W_embed.pos_learnable:
+           self.projection.Q_embed.pos_weights.set(self.embedding.W_embed.pos_weights.get())
+        for i in range(self.n_layers):
+            block_proj= self.projection.blocks[i]
+            block= self.blocks[i] 
+            block_proj.Q_q.weights.set(block.attention.W_q.weights.get())
+            block_proj.Q_q.biases.set(block.attention.W_q.biases.get())
+            block_proj.Q_k.weights.set(block.attention.W_k.weights.get())
+            block_proj.Q_k.biases.set(block.attention.W_k.biases.get())
+            block_proj.Q_v.weights.set(block.attention.W_v.weights.get())
+            block_proj.Q_v.biases.set(block.attention.W_v.biases.get())
+            block_proj.Q_attn_out.weights.set(block.attention.W_attn_out.weights.get())
+            block_proj.q_attn_block.inputs_q.set(block.attention.attn_block.inputs_q.get())
+            block_proj.q_attn_block.inputs_k.set(block.attention.attn_block.inputs_k.get())
+            block_proj.q_attn_block.inputs_v.set(block.attention.attn_block.inputs_v.get())
+            block_proj.Q_attn_out.biases.set(block.attention.W_attn_out.biases.get())
+            block_proj.Q_mlp1.weights.set(block.mlp.W_mlp1.weights.get())
+            block_proj.Q_mlp1.biases.set(block.mlp.W_mlp1.biases.get())
+            block_proj.Q_mlp2.weights.set(block.mlp.W_mlp2.weights.get())
+            block_proj.Q_mlp2.biases.set(block.mlp.W_mlp2.biases.get())
 
-        # self.projection.Q_out.weights.set(self.output.W_out.weights.get())
-        # self.projection.Q_out.biases.set(self.output.W_out.biases.get())
+        self.projection.Q_out.weights.set(self.output.W_out.weights.get())
+        self.projection.Q_out.biases.set(self.output.W_out.biases.get())
         # self.projection.q_target_Ratecell.j_td.set(jnp.zeros((self.batch_size * self.seq_len, self.vocab_size)))
         
        
         self.clamp_input(obs)
         self.clamp_infer_target(lab)
         
-        # self.project.run(t=0., dt=1.)
+        self.project.run(t=0., dt=1.)
 
 
         for i in range(self.n_layers):
-        #     block_proj= self.projection.blocks[i]   
+            block_proj= self.projection.blocks[i]   
             b= self.blocks[i]
-        #     b.attention.z_qkv.z.set(block_proj.q_qkv_Ratecell.z.get())
-        #     b.mlp.z_mlp.z.set(block_proj.q_mlp_Ratecell.z.get())
-        #     b.mlp.z_mlp2.z.set(block_proj.q_mlp2_Ratecell.z.get())
+            b.attention.z_qkv.z.set(block_proj.q_qkv_Ratecell.z.get())
+            b.mlp.z_mlp.z.set(block_proj.q_mlp_Ratecell.z.get())
+            b.mlp.z_mlp2.z.set(block_proj.q_mlp2_Ratecell.z.get())
             b.attention.E_q.weights.set(jnp.transpose(b.attention.W_q.weights.get()))
             b.attention.E_k.weights.set(jnp.transpose(b.attention.W_k.weights.get()))
             b.attention.E_v.weights.set(jnp.transpose(b.attention.W_v.weights.get()))
@@ -554,13 +555,13 @@ class NGCTransformer:
             b.mlp.E_mlp1.weights.set(jnp.transpose(b.mlp.W_mlp1.weights.get()))
        
         self.output.E_out.weights.set(jnp.transpose(self.output.W_out.weights.get()))
-        # self.output.z_out.z.set(self.projection.q_out_Ratecell.z.get())
-        # self.output.e_out.dmu.set(self.projection.eq_target.dmu.get())
-        # self.output.e_out.dtarget.set(self.projection.eq_target.dtarget.get())
+        self.output.z_out.z.set(self.projection.q_out_Ratecell.z.get())
+        self.output.e_out.dmu.set(self.projection.eq_target.dmu.get())
+        self.output.e_out.dtarget.set(self.projection.eq_target.dtarget.get())
         
         
         ## get projected prediction (from the P-step)
-        y_mu_inf = self.projection.q_target_Ratecell.z.get()
+        y_mu_inf = self.projection.q_target_Ratecell.zF.get()
     
         EFE = 0. 
         y_mu = 0.
@@ -583,7 +584,7 @@ class NGCTransformer:
                 block = self.blocks[i]
                 block_errors += block.attention.e_attn.L.get() + block.mlp.e_mlp.L.get() + block.mlp.e_mlp1.L.get()
 
-        EFE = L4 + block_errors + L1
+        EFE = block_errors + L1
 
         if adapt_synapses == True:
                 self.embedding_evolve.run()


### PR DESCRIPTION
Different prompts were producing nearly identical generated outputs. This PR addresses the root causes and improves prompt sensitivity and generation diversity.

Root Cause

Inference was using a hard-coded padding token (0) and always enabling target clamping. In a predictive-coding transformer, that combination — along with non-causal context — overpowers the prompt signal, causing different prompts to converge to almost the same output.

**Changes Made**



Replaced the hard-coded padding token with the tokenizer's real pad_token_id to ensure correct sequence boundary handling.
Added logic to correctly compute the last real token position after truncation and padding.
Introduced optional top-k sampling to replace repetitive argmax generation and improve output diversity.
Switched the output logits to use the inferred prediction (y_mu_inf) with a dummy target during inference, 


**Result**



Different prompts now produce meaningfully distinct outputs, and generation quality is more varied and prompt-responsive.

for this we use no Prompt and the model generate the prompt to compare with standard transformer