### PR TITLE
Optimization: Implement fused advance loop with jax.lax.scan for training speedup

### DIFF
--- a/config.py
+++ b/config.py
@@ -32,3 +32,6 @@ class Config:
     # When tokenizer == "BPE", tokenizer_vocab_file may point to a vocab json or a newline token list.
     # Optional: set to None to use a simple fallback whitespace tokenizer.
     tokenizer_vocab_file = None
+
+    # set True to Use jax.lax.scan fused advance loop (faster, minor floating-point differences from the normal python loop)
+    fused_advance = True

--- a/model.py
+++ b/model.py
@@ -394,10 +394,11 @@ class NGCTransformer:
                 self.project = project_process
                 self.embedding_evolve=embedding_evolve_process
 
-                
+        if getattr(config, "fused_advance", True):
+            print("\nUsing fused advance loop (jax.lax.scan)")
+        else:
+            print("\nUsing normal for-loop advance")
 
-
-    
     def clamp_input(self,x):
         self.embedding.z_embed.j.set(x)
         self.projection.q_embed_Ratecell.j.set(x) 
@@ -564,7 +565,6 @@ class NGCTransformer:
         self.clamp_target(lab)
 
         if getattr(config, "fused_advance", True):
-            print("Using fused advance...")
             advance_fn = self.advance.run.compiled
             state = global_state_manager.state
             kwargs = jnp.full((self.T,), 1.0, dtype=jnp.float32)
@@ -576,7 +576,6 @@ class NGCTransformer:
             final_state, _ = jax.lax.scan(scan_fn, state, kwargs)
             global_state_manager.set_state(final_state)
         else:
-            print("Using non-fused advance(normal for-loop)...")
             for ts in range(0, self.T):
                 self.clamp_input(obs)
                 self.clamp_target(lab)

--- a/model.py
+++ b/model.py
@@ -15,6 +15,7 @@ from layers.mlp import MLP
 from layers.output import Output
 from utils.model_util import ReshapeComponent, Outgrad
 from projection.projection import Projection
+from ngcsimlib._src.global_state.manager import global_state_manager
 import numpy as np
 
 
@@ -558,18 +559,21 @@ class NGCTransformer:
         
         ## get projected prediction (from the P-step)
         y_mu_inf = self.projection.q_target_Ratecell.zF.get()
-    
-        EFE = 0. 
-        y_mu = 0.
-        #if adapt_synapses:
-        for ts in range(0, self.T):
-        
-            self.clamp_input(obs)
-            self.clamp_target(lab)
-             
-            self.advance.run(t=ts,dt=1.)
-           
-        # y_mu = self.output.W_out.outputs.get() 
+
+        self.clamp_input(obs)
+        self.clamp_target(lab)
+
+        advance_fn = self.advance.run.compiled
+        state = global_state_manager.state
+        kwargs = jnp.full((self.T,), 1.0, dtype=jnp.float32)
+
+        def scan_fn(ctx, dt):
+            new_ctx, _ = advance_fn(ctx, [dt])
+            return new_ctx, None
+
+        final_state, _ = jax.lax.scan(scan_fn, state, kwargs)
+        global_state_manager.set_state(final_state)
+
         y_mu = self.z_actfx.zF.get() 
 
         L1 = self.embedding.e_embed.L.get()

--- a/model.py
+++ b/model.py
@@ -563,16 +563,24 @@ class NGCTransformer:
         self.clamp_input(obs)
         self.clamp_target(lab)
 
-        advance_fn = self.advance.run.compiled
-        state = global_state_manager.state
-        kwargs = jnp.full((self.T,), 1.0, dtype=jnp.float32)
+        if getattr(config, "fused_advance", True):
+            print("Using fused advance...")
+            advance_fn = self.advance.run.compiled
+            state = global_state_manager.state
+            kwargs = jnp.full((self.T,), 1.0, dtype=jnp.float32)
 
-        def scan_fn(ctx, dt):
-            new_ctx, _ = advance_fn(ctx, [dt])
-            return new_ctx, None
+            def scan_fn(ctx, dt):
+                new_ctx, _ = advance_fn(ctx, [dt])
+                return new_ctx, None
 
-        final_state, _ = jax.lax.scan(scan_fn, state, kwargs)
-        global_state_manager.set_state(final_state)
+            final_state, _ = jax.lax.scan(scan_fn, state, kwargs)
+            global_state_manager.set_state(final_state)
+        else:
+            print("Using non-fused advance(normal for-loop)...")
+            for ts in range(0, self.T):
+                self.clamp_input(obs)
+                self.clamp_target(lab)
+                self.advance.run(t=ts, dt=1.)
 
         y_mu = self.z_actfx.zF.get() 
 

--- a/train.py
+++ b/train.py
@@ -72,7 +72,8 @@ def main():
         if i == (epoch-1):
           model.save_to_disk(params_only=False) # save final state of model to disk
     total_time = time.time() - start_time
-    print(f"\nTraining finished. Total time: {total_time:.2f}s ({total_time/60:.2f} min)")
+    print(f"\nTraining finished.")
+    print(f"Total training time: {total_time:.2f} seconds ({total_time/60:.2f} min)")
    
 if __name__ == "__main__":
     main()

--- a/train.py
+++ b/train.py
@@ -72,8 +72,7 @@ def main():
         if i == (epoch-1):
           model.save_to_disk(params_only=False) # save final state of model to disk
     total_time = time.time() - start_time
-    print(f"\nTraining finished.")
-    print(f"Total training time: {total_time:.0f} seconds")
+    print(f"\nTraining finished. Total time: {total_time:.2f}s ({total_time/60:.2f} min)")
    
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
### This PR:
Optimizes the Predictive Coding Transformer training loop by fusing the T-step
advance iterations into a single XLA computation using `jax.lax.scan`.

**Before**: Python `for ts in range(T)` loop with 26 separate `advance.run()`
calls per batch - each iteration is copying the entire global state dict (which creates high performance bottleneck (simply takes longer to finish training).

**After**: Single `jax.lax.scan` call fusing all T iterations - state stays within
XLA, eliminating T-1 Python dict copies and JAX dispatch overhead per batch.

### Performance Comparison ( using the original configs: like seq_len=64, n_embed=96, n_heads=8, n_iter=26)
When train just for 200 bache, those time variations have been discovered.
| Method | 200 batches | Speedup |
|--------|:-----------:|:-------:|
| Normal for-loop | **45.6 min** | 1.00x |
| **Fused (lax.scan)** | **2.8 min** | **16.4x** |

Training metrics converge identically like that of the normal for loop. but it optimizes the time complexity a lot as written above. 

### Changes

- `model.py`: Replace Python advance loop with `jax.lax.scan`; move `clamp_input`/  `clamp_target` outside the loop (since they were redundant per-iteration)
- `config.py`: Add `fused_advance` toggle for reproducibility fallback
- Diagnostic print now fires once at model init so to identify what is being used at runtime.

### Verification

This image below is added to show the time optimization after applying jax.lax.scan just for 200 baches:

<img width="923" height="659" alt="image" src="https://github.com/user-attachments/assets/e9ee251b-9d7d-49cf-a001-e857e9bed503" />


Using the normal python for-loop, it takes more than 45 Minutes to train with all the exact hyperparameter configurations.
