### PR TITLE
Add Configurable Positional Embedding Support (RoPE or Learned Positional Embeddings)

### DIFF
--- a/config.py
+++ b/config.py
@@ -16,7 +16,7 @@ class Config:
     tau_o = 2
 
     #configuration of encoding either rope or positional
-    postion_encoding= "rope"
+    position_encoding= "rope"
 
     # Used only when position_encoding == "positional"
     # True: learned absolute embeddings

--- a/config.py
+++ b/config.py
@@ -9,11 +9,22 @@ class Config:
     dropout_rate = 0.0
     eta = 4.919042890915579e-06
     eta_o= 2.9e-03
-    exp_dir = "exp" 
+    exp_dir = "exp_rope" # either "exp_rope" or "exp_positional_learned" -r "exp_positional_fixed"
     optim_type = "sgd"
     epoch = 1
     n_iter= 26
     tau_o = 2
+
+    #configuration of encoding either rope or positional
+    postion_encoding= "rope"
+
+    # Used only when position_encoding == "positional"
+    # True: learned absolute embeddings
+    # False: fixed sinusoidal embeddings
+    pos_learnable = True
+
+    rope_theta = 10000.0
+
     # Approximate Xavier scaling: 1 / sqrt(512) is about 0.04
     wub = 0.035284728580901155
     wlb =  -0.07318664527441558

--- a/config.py
+++ b/config.py
@@ -21,7 +21,7 @@ class Config:
     # Used only when position_encoding == "positional"
     # True: learned absolute embeddings
     # False: fixed sinusoidal embeddings
-    pos_learnable = True
+    pos_learnable = False 
 
     rope_theta = 10000.0
 

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ class Config:
     dropout_rate = 0.0
     eta = 4.919042890915579e-06
     eta_o= 2.9e-03
-    exp_dir = "exp_rope" # either "exp_rope" or "exp_positional_learned" -r "exp_positional_fixed"
+    exp_dir = "exp_rope" # either "exp_rope" or "exp_positional_learned" or "exp_positional_fixed"
     optim_type = "sgd"
     epoch = 1
     n_iter= 26

--- a/eval.py
+++ b/eval.py
@@ -48,6 +48,15 @@ def load_weights_into_model(model, model_dir):
     embed_data = jnp.load(os.path.join(custom_dir, "W_embed.npz"))
     model.embedding.W_embed.word_weights.set(embed_data["word_weights"])
 
+    if model.use_positional and model.pos_learnable:
+        if "pos_weights" not in embed_data:
+            raise ValueError(
+                "Checkpoint has no pos_weights. "
+                "Check the configured mode and checkpoint directory."
+
+            )
+        model.embedding.W_embed.pos_weights.set(embed_data["pos_weights"])
+
 
     for i in range(model.n_layers):
         for name in ["W_q", "W_k", "W_v", "W_attn_out", "W_mlp1", "W_mlp2"]:
@@ -85,9 +94,12 @@ if __name__ == "__main__":
         act_fx=config.act_fx,
         eta=config.eta,
         dropout_rate=config.dropout_rate,
-        exp_dir="exp",
+        exp_dir=config.exp_dir,
+        position_encoding=config.position_encoding,
+        pos_learnable=config.pos_learnable,
+        rope_theta=config.rope_theta,
         model_name="ngc_transformer",
-        loadDir="exp",  
+        loadDir=config.exp_dir,  
         optim_type=config.optim_type,
         wub=config.wub,
         wlb=config.wlb,

--- a/generation.py
+++ b/generation.py
@@ -114,8 +114,11 @@ if __name__ == "__main__":
         act_fx=config.act_fx, 
         eta=config.eta, 
         dropout_rate=config.dropout_rate, 
-        exp_dir="exp",
-        loadDir="exp", # Ensure model is loaded from trained exp/ directory
+        exp_dir=config.exp_dir,
+        loadDir=config.exp_dir, # Ensure model is loaded from trained exp/ directory
+        position_encoding=config.position_encoding,
+        pos_learnable=config.pos_learnable,
+        rope_theta=config.rope_theta,
         optim_type=config.optim_type, 
         wub=config.wub, 
         wlb=config.wlb, 

--- a/layers/attention.py
+++ b/layers/attention.py
@@ -28,7 +28,7 @@ class Attention:
         eta: Learning rate for Hebbian synapses
     """
         
-    def __init__(self, dkey, n_embed, seq_len, batch_size, n_heads, dropout_rate, eta, optim_type, wub, wlb, prefix, tau_m, **kwargs):
+    def __init__(self, dkey, n_embed, seq_len, batch_size, n_heads, dropout_rate, eta, optim_type, wub, wlb, prefix, tau_m,position_encoding, rope_theta, **kwargs):
     
         dkey, *subkeys = random.split(dkey, 10)
 
@@ -55,7 +55,9 @@ class Attention:
         self.attn_block = AttentionBlock(f"{prefix}attn_block", n_heads=n_heads, 
                                        n_embed=n_embed, seq_len=seq_len,
                                        dropout_rate=dropout_rate, 
-                                       batch_size=batch_size)
+                                       batch_size=batch_size,
+                                       position_encoding=position_encoding,
+                                       rope_theta=rope_theta,)
         
         self.W_attn_out = HebbianSynapse(f"{prefix}W_attn_out", shape=(n_embed, n_embed), batch_size=batch_size * seq_len, eta=eta,
                             weight_init=dist.gaussian(mean=0.0, std=0.01

--- a/layers/blocks.py
+++ b/layers/blocks.py
@@ -8,7 +8,7 @@ from utils.rms_norm_util import RMSNorm
 
 class Block:
     def __init__(self, dkey, block_id, n_embed, seq_len, vocab_size,
-                 batch_size, n_heads, dropout_rate, eta, optim_type, wub, wlb, tau_m, **kwargs):
+                 batch_size, n_heads, dropout_rate, eta, optim_type, wub, wlb, tau_m,position_encoding, rope_theta, **kwargs):
         
         dkey, attn_key, mlp_key = random.split(dkey, 3)
         prefix = f"block{block_id}_"
@@ -17,7 +17,7 @@ class Block:
 
         self.attention = Attention(dkey=attn_key, n_embed=n_embed, seq_len=seq_len,
                                  batch_size=batch_size, n_heads=n_heads,
-                                 dropout_rate=dropout_rate, eta=eta, optim_type= optim_type, wub=wub, wlb=wlb, prefix=prefix, tau_m=tau_m)
+                                 dropout_rate=dropout_rate, eta=eta, optim_type= optim_type, wub=wub, wlb=wlb, prefix=prefix, tau_m=tau_m, position_encoding=position_encoding, rope_theta=rope_theta)
         
         # self.ln2 = RMSNorm(f"{prefix}ln2", n_embed=n_embed, batch_size= batch_size * seq_len)
         self.mlp = MLP(dkey=mlp_key, n_embed=n_embed, seq_len=seq_len,

--- a/layers/embedding.py
+++ b/layers/embedding.py
@@ -9,7 +9,7 @@ class EMBEDDING:
     """
    embedding layer using the EmbeddingSynapse
     """
-    def __init__(self, dkey, vocab_size, seq_len, embed_dim, batch_size, eta, optim_type, **kwargs):
+    def __init__(self, dkey, vocab_size, seq_len, embed_dim, batch_size, eta, optim_type, postion_encoding, pos_learnable, **kwargs):
         
         dkey, *subkeys = random.split(dkey, 4)
     
@@ -25,6 +25,8 @@ class EMBEDDING:
                 batch_size=batch_size,
                 eta=eta,
                 optim_type=optim_type,
+                position_encoding=postion_encoding,
+                pos_learnable=pos_learnable,
                 key=subkeys[0])
             
         self.e_embed = ErrorCell("e_embed", n_units=embed_dim, 

--- a/layers/embedding.py
+++ b/layers/embedding.py
@@ -9,7 +9,7 @@ class EMBEDDING:
     """
    embedding layer using the EmbeddingSynapse
     """
-    def __init__(self, dkey, vocab_size, seq_len, embed_dim, batch_size, eta, optim_type, postion_encoding, pos_learnable, **kwargs):
+    def __init__(self, dkey, vocab_size, seq_len, embed_dim, batch_size, eta, optim_type, position_encoding, pos_learnable, **kwargs):
         
         dkey, *subkeys = random.split(dkey, 4)
     
@@ -25,7 +25,7 @@ class EMBEDDING:
                 batch_size=batch_size,
                 eta=eta,
                 optim_type=optim_type,
-                position_encoding=postion_encoding,
+                position_encoding=position_encoding,
                 pos_learnable=pos_learnable,
                 key=subkeys[0])
             

--- a/model.py
+++ b/model.py
@@ -46,7 +46,7 @@ class NGCTransformer:
     """
 
    
-    def __init__(self, dkey, batch_size, seq_len, n_embed, vocab_size, n_layers, n_heads, T, dt, tau_m, act_fx, eta, dropout_rate, exp_dir, model_name, loadDir=None, optim_type="adam", wub=1.0, wlb=0.0, **kwargs):
+    def __init__(self, dkey, batch_size, seq_len, n_embed, vocab_size, n_layers, n_heads, T, dt, tau_m, act_fx, eta, dropout_rate, exp_dir, model_name, loadDir=None,position_encoding="rope",pos_learnable=True,rope_theta=10000.0, optim_type="adam", wub=1.0, wlb=0.0, **kwargs):
 
         self.exp_dir = exp_dir
         self.model_name = model_name
@@ -57,7 +57,10 @@ class NGCTransformer:
         self.seq_len= seq_len
         self.vocab_size= vocab_size
         self.n_embed= n_embed
-        
+        self.position_encoding = position_encoding
+        self.use_positional = position_encoding == "positional"
+        self.pos_learnable = pos_learnable
+        self.rope_theta = rope_theta
         if exp_dir is not None:
             makedir(exp_dir)
             makedir(exp_dir + "/filters")
@@ -66,13 +69,13 @@ class NGCTransformer:
        
         with Context("Circuit") as self.circuit:
                 
-            self.embedding = EMBEDDING(dkey=subkeys[0], vocab_size=self.vocab_size, seq_len=self.seq_len, embed_dim=self.n_embed, batch_size=self.batch_size, eta=eta, optim_type=optim_type)
+            self.embedding = EMBEDDING(dkey=subkeys[0], vocab_size=self.vocab_size, seq_len=self.seq_len, embed_dim=self.n_embed, batch_size=self.batch_size, eta=eta, optim_type=optim_type, position_encoding=self.position_encoding, pos_learnable=self.pos_learnable)
                 
             self.blocks = []
             for i in range(n_layers):
                 key, subkey = random.split(subkeys[1 + i])
                 block=Block(dkey=subkey, block_id= i, n_embed=self.n_embed, seq_len=self.seq_len,
-                                batch_size=self.batch_size, vocab_size=self.vocab_size, n_heads=n_heads, dropout_rate=dropout_rate, eta=eta, optim_type=optim_type, wub=wub, wlb=wlb, tau_m=tau_m)
+                                batch_size=self.batch_size, vocab_size=self.vocab_size, n_heads=n_heads, dropout_rate=dropout_rate, eta=eta, optim_type=optim_type, wub=wub, wlb=wlb, tau_m=tau_m, position_encoding=self.position_encoding, rope_theta=self.rope_theta)
                 self.blocks.append(block)   
                     
             self.output = Output(dkey=subkeys[3], n_embed=self.n_embed, seq_len=self.seq_len, batch_size=self.batch_size, vocab_size=self.vocab_size, eta=eta, optim_type=optim_type, wlb=wlb, wub=wub, tau_m=tau_m)
@@ -80,7 +83,7 @@ class NGCTransformer:
             self.z_target=RateCell("z_target", n_units= self.vocab_size, tau_m=0., act_fx="identity", batch_size=self.batch_size * self.seq_len) 
             self.z_actfx= RateCell("z_actfx", n_units= self.vocab_size, tau_m=tau_m, act_fx="softmax", batch_size=self.batch_size * self.seq_len)
             self.projection = Projection(dkey=subkeys[29], n_embed=self.n_embed, seq_len=self.seq_len, batch_size=self.batch_size,
-                                             vocab_size=self.vocab_size, eta=eta, optim_type=optim_type, wub=wub, wlb=wlb, n_blocks=n_layers, n_heads=n_heads, dropout_rate=dropout_rate)
+                                             vocab_size=self.vocab_size, eta=eta, optim_type=optim_type, wub=wub, wlb=wlb, n_blocks=n_layers, n_heads=n_heads, dropout_rate=dropout_rate , position_encoding=self.position_encoding, pos_learnable=self.pos_learnable, rope_theta=self.rope_theta,)
             self.reshape_4d_to_2d = ReshapeComponent("reshape_4d_to_2d",
                                             input_shape=(self.batch_size, self.seq_len, self.n_embed, 1),
                                             output_shape=(self.batch_size * self.seq_len, self.n_embed))
@@ -445,6 +448,15 @@ class NGCTransformer:
         self.embedding_evolve = processes.get("embedding_evolve_process", self.evolve) 
 
         self.embedding.W_embed.word_weights.set(self.circuit.get_components("W_embed").word_weights.get())
+        if self.use_positional and self.pos_learnable:
+            if not hasattr(self.circuit.get_components("W_embed"), "pos_weights"):
+                raise ValueError(
+                    "Loaded model has no pos_weights."
+                    "It may have been trained with position_encoding='rope'."               
+                )
+            self.embedding.W_embed.pos_weights.set(
+                self.circuit.get_components("W_embed").pos_weights.get()
+            )
         self.output.W_out.weights.set(self.circuit.get_components("W_out").weights.get())
         self.output.W_out.biases.set(self.circuit.get_components("W_out").biases.get())
       
@@ -506,6 +518,8 @@ class NGCTransformer:
         
         self.reset.run()
         self.projection.Q_embed.word_weights.set(self.embedding.W_embed.word_weights.get())
+        if self.use_positional:
+            self.projection.Q_embed.pos_weights.set(self.embedding.W_embed.pos_weights.get())
         for i in range(self.n_layers):
             block_proj= self.projection.blocks[i]
             block= self.blocks[i] 
@@ -602,6 +616,9 @@ class NGCTransformer:
         total = 0
         # Embedding weights
         total += self.embedding.W_embed.word_weights.get().size
+
+        if self.use_positional and self.pos_learnable:
+            total += self.embedding.W_embed.pos_weights.get().size
         # Transformer blocks
         for block in self.blocks:
             for W in [block.attention.W_q, block.attention.W_k,

--- a/model.py
+++ b/model.py
@@ -46,7 +46,7 @@ class NGCTransformer:
     """
 
    
-    def __init__(self, dkey, batch_size, seq_len, n_embed, vocab_size, n_layers, n_heads, T, dt, tau_m, act_fx, eta, dropout_rate, exp_dir, model_name, loadDir=None,position_encoding="rope",pos_learnable=True,rope_theta=10000.0, optim_type="adam", wub=1.0, wlb=0.0, **kwargs):
+    def __init__(self, dkey, batch_size, seq_len, n_embed, vocab_size, n_layers, n_heads, T, dt, tau_m, act_fx, eta, dropout_rate, exp_dir, model_name, loadDir=None,position_encoding="rope",pos_learnable=False,rope_theta=10000.0, optim_type="adam", wub=1.0, wlb=0.0, **kwargs):
 
         self.exp_dir = exp_dir
         self.model_name = model_name

--- a/projection/proj_block.py
+++ b/projection/proj_block.py
@@ -11,7 +11,7 @@ from utils.model_util import ReshapeComponent
 
 class ProjBlock:
     def __init__(self, dkey, block_id, n_embed, seq_len, vocab_size,
-                 batch_size, n_heads, dropout_rate, eta, optim_type, wub, wlb, **kwargs):
+                 batch_size, n_heads, dropout_rate, eta, optim_type, wub, wlb,position_encoding, rope_theta, **kwargs):
         
         dkey, *subkeys = random.split(dkey, 20)
         prefix = f"block_proj{block_id}_"
@@ -36,7 +36,7 @@ class ProjBlock:
         self.q_attn_block = AttentionBlock(f"{prefix}q_attn_block",
 
                                    n_heads=n_heads, n_embed=n_embed, seq_len=seq_len,
-                                   dropout_rate=dropout_rate, batch_size=batch_size)
+                                   dropout_rate=dropout_rate, batch_size=batch_size, position_encoding=position_encoding, rope_theta=rope_theta)
                 
         
         self.Q_attn_out = StaticSynapse(f"{prefix}Q_attn_out", shape=(n_embed, n_embed),

--- a/projection/projection.py
+++ b/projection/projection.py
@@ -5,7 +5,7 @@ from ngclearn.utils.distribution_generator import DistributionGenerator as dist
 from projection.proj_block import ProjBlock
 from jax import random
 class Projection():
-    def __init__(self, dkey, n_embed, seq_len, batch_size, vocab_size, eta, optim_type, wub, wlb, n_blocks, n_heads, dropout_rate,  **kwargs):
+    def __init__(self, dkey, n_embed, seq_len, batch_size, vocab_size, eta, optim_type, wub, wlb, n_blocks, n_heads, dropout_rate, position_encoding,pos_learnable, rope_theta, **kwargs):
         dkey, *subkeys = random.split(dkey, 20)
         
         self.q_embed_Ratecell = RateCell("q_embed_Ratecell", n_units=seq_len, tau_m=0., act_fx="identity",
@@ -19,7 +19,7 @@ class Projection():
         self.Q_embed = EmbeddingSynapse("Q_embed", vocab_size=vocab_size, seq_len=seq_len,
                                 embed_dim=n_embed, batch_size= batch_size,
                                 eta=eta,
-                                 optim_type=optim_type, key=subkeys[5])
+                                 optim_type=optim_type,position_encoding=position_encoding,pos_learnable=pos_learnable, key=subkeys[5])
                 
         self.blocks=[]
         for k in range(n_blocks):
@@ -34,7 +34,9 @@ class Projection():
                           eta=eta,
                           optim_type=optim_type,
                           wub=wub,
-                          wlb=wlb)
+                          wlb=wlb,
+                          position_encoding=position_encoding,
+                          rope_theta=rope_theta,)
             self.blocks.append(block)       
         
         self.Q_out = StaticSynapse("Q_out", shape=(n_embed, vocab_size),  bias_init=dist.constant(value=0.), key=subkeys[12])

--- a/train.py
+++ b/train.py
@@ -29,7 +29,7 @@ def main():
     
     model = NGCTransformer(dkey, batch_size=batch_size, seq_len=seq_len, n_embed=n_embed, vocab_size=vocab_size, n_layers=n_layers, n_heads=n_heads,
                           T=T, dt=1., tau_m=tau_m , act_fx=act_fx, eta=eta, dropout_rate= dropout_rate, exp_dir=config.exp_dir,
-                  loadDir= None, optim_type=optim_type, wub = wub, wlb= wlb,position_encoding=config.postion_encoding,pos_learnable=config.pos_learnable,rope_theta=config.rope_theta, model_name="ngc_transformer" )
+                  loadDir= None, optim_type=optim_type, wub = wub, wlb= wlb,position_encoding=config.position_encoding,pos_learnable=config.pos_learnable,rope_theta=config.rope_theta, model_name="ngc_transformer" )
 
     #print the selected mode
     print(f"Position encoding: {config.position_encoding}")

--- a/train.py
+++ b/train.py
@@ -28,9 +28,14 @@ def main():
     train_loader, valid_loader, _ = data_loader.load_and_prepare_data()
     
     model = NGCTransformer(dkey, batch_size=batch_size, seq_len=seq_len, n_embed=n_embed, vocab_size=vocab_size, n_layers=n_layers, n_heads=n_heads,
-                          T=T, dt=1., tau_m=tau_m , act_fx=act_fx, eta=eta, dropout_rate= dropout_rate, exp_dir="exp",
-                  loadDir= None, optim_type=optim_type, wub = wub, wlb= wlb, model_name="ngc_transformer" )
+                          T=T, dt=1., tau_m=tau_m , act_fx=act_fx, eta=eta, dropout_rate= dropout_rate, exp_dir=config.exp_dir,
+                  loadDir= None, optim_type=optim_type, wub = wub, wlb= wlb,position_encoding=config.postion_encoding,pos_learnable=config.pos_learnable,rope_theta=config.rope_theta, model_name="ngc_transformer" )
 
+    #print the selected mode
+    print(f"Position encoding: {config.position_encoding}")
+    if config.position_encoding == "positional":
+         print(f"Learnable positions: {config.pos_learnable}")
+    
     print(f" {model.count_parameters()/1e6:.2f} M parameters")
 
     def train_model(data_loader):

--- a/tuning.py
+++ b/tuning.py
@@ -108,7 +108,10 @@ def create_model_with_all_params(trial_number, params, cfg):
         "optim_type": cfg.optim_type,
         "wub": cfg.wub,
         "wlb": cfg.wlb,
-        "model_name": f"trial_{trial_number}"
+        "model_name": f"trial_{trial_number}",
+        "position_encoding": cfg.position_encoding,
+        "pos_learnable": cfg.pos_learnable,
+        "rope_theta": cfg.rope_theta,
     }
 
     model = NGCTransformer(**model_args)

--- a/utils/attention_utils.py
+++ b/utils/attention_utils.py
@@ -228,13 +228,28 @@ class AttentionBlock(JaxComponent):
     def help(cls):
         """Component help function"""
         properties = {
-            "component_type": "AttentionBlock - multi-head self-attention with built-in causal mask"
+            "component_type": "AttentionBlock - multi-head self-attention with built-in causal mask and optional rotary position encoding"
         }
         compartment_props = {
             "inputs": 
                 {"inputs_q": "Query inputs (batch_size, seq_len, n_embed)",
                 "inputs_k": "Key inputs (batch_size, seq_len, n_embed)", 
                 "inputs_v": "Value inputs (batch_size, seq_len, n_embed)"},
+            "states": {
+                "cos": (
+                    "Precomputed RoPE cosine values "
+                    "(seq_len, d_head); identity values are used when "
+                    "position_encoding='positional'"
+                ),
+                "sin": (
+                    "Precomputed RoPE sine values "
+                    "(seq_len, d_head); zero values are used when "
+                    "position_encoding='positional'"
+                ),
+                "key": (
+                    "JAX pseudo-random key used for attention dropout"
+                ),
+            },
             "gradients":
                 {"dq": "Gradient w.r.t Q (batch_size*seq_len, n_embed)",
                 "dk": "Gradient w.r.t K (batch_size*seq_len, n_embed)",
@@ -248,10 +263,21 @@ class AttentionBlock(JaxComponent):
             "n_embed": "Embedding dimension", 
             "seq_len": "Sequence length",
             "dropout_rate": "Attention dropout rate",
-            "batch_size": "Batch size dimension"
+            "batch_size": "Batch size dimension",
+            "position_encoding": (
+                "Position-encoding mode: 'rope' or 'positional'"
+            ),
+            "rope_theta": (
+                "RoPE frequency base; used only when "
+                "position_encoding='rope'"
+            ),
         }
         info = {cls.__name__: properties,
                 "compartments": compartment_props,
-                "dynamics": "outputs = MultiHeadAttention(Q, K, V) with built-in causal mask",
+                "dynamics": (
+                    "rope: outputs = CausalMultiHeadAttention("
+                    "RoPE(Q), RoPE(K), V); "
+                    "positional: outputs = CausalMultiHeadAttention(Q, K, V)"
+                ),
                 "hyperparameters": hyperparams}
         return info

--- a/utils/attention_utils.py
+++ b/utils/attention_utils.py
@@ -9,7 +9,7 @@ from utils.model_util import d_softmax_vjp
 from utils.rope_utils import apply_rotary_emb, apply_rotary_emb_inv, precompute_freqs_cis_real
 
 @partial(jit, static_argnums=[6, 7, 8, 9, 10])
-def _compute_attention(Q, K, V, cos, sin, mask, n_heads, d_head, dropout_rate, seq_len, batch_size, key):
+def _compute_attention(Q, K, V, cos, sin, mask, n_heads, d_head, dropout_rate, seq_len, batch_size, use_rope,  key):
     """
     Compute multi-head attention with RoPE
     """
@@ -26,10 +26,14 @@ def _compute_attention(Q, K, V, cos, sin, mask, n_heads, d_head, dropout_rate, s
     k = K.reshape((B, S, n_heads, d_head)).transpose([0, 2, 1, 3]) 
     v = V.reshape((B, S, n_heads, d_head)).transpose([0, 2, 1, 3])
     
-    q, k = apply_rotary_emb(q, k, cos, sin)
+    if use_rope:
+        q_used, k_used = apply_rotary_emb(q, k, cos, sin)
+    else:
+        q_used, k_used = q,k
+    
     
     # Scaled dot-product attention
-    s_c = jnp.einsum("BHTE,BHSE->BHTS", q, k) / jnp.sqrt(d_head)
+    s_c = jnp.einsum("BHTE,BHSE->BHTS", q_used, k_used) / jnp.sqrt(d_head)
     
   
     _mask = mask[None, None, :, :]  
@@ -46,11 +50,11 @@ def _compute_attention(Q, K, V, cos, sin, mask, n_heads, d_head, dropout_rate, s
     attention = jnp.einsum("BHTS,BHSE->BHTE", score, v)
     attention = attention.transpose([0, 2, 1, 3]).reshape((B, S, -1))
     
-    return attention, s_c, q, k, v
+    return attention, s_c, q_used, k_used, v
 
 
 @partial(jit, static_argnums=[8, 9, 10, 11, 12])
-def compute_grads(Q_rot, K_rot, V, cos, sin, mask, s_c, dmu, n_heads, d_head, dropout_rate, seq_len, batch_size, key):
+def compute_grads(Q_rot, K_rot, V, cos, sin, mask, s_c, dmu, n_heads, d_head, dropout_rate, seq_len, batch_size,use_rope, key):
     """Compute gradients for Q, K, V using d_softmax and attention scores
     """
     B = batch_size
@@ -75,7 +79,10 @@ def compute_grads(Q_rot, K_rot, V, cos, sin, mask, s_c, dmu, n_heads, d_head, dr
     dK_rot = jnp.einsum("bhkq,bhqd->bhkd", ds, Q_rot)  # (B, H, S, D)
     
     # Inverse RoPE to get raw Q and K gradients
-    dQ_raw, dK_raw = apply_rotary_emb_inv(dQ_rot, dK_rot, cos, sin)
+    if use_rope:
+        dQ_raw, dK_raw = apply_rotary_emb_inv(dQ_rot, dK_rot, cos, sin)
+    else:
+        dQ_raw, dK_raw = dQ_rot, dK_rot
     
     # 6. Reshape to flattened format
     dq = dQ_raw.transpose(0, 2, 1, 3).reshape(B * S, H * D)
@@ -111,7 +118,7 @@ class AttentionBlock(JaxComponent):
         batch_size: Batch size
     """
     
-    def __init__(self, name, n_heads, n_embed, seq_len, dropout_rate, batch_size, **kwargs):
+    def __init__(self, name, n_heads, n_embed, seq_len, dropout_rate, batch_size, position_encoding="rope", rope_theta=10000.0, **kwargs):
         super().__init__(name, **kwargs)
 
         self.n_heads = n_heads
@@ -120,13 +127,23 @@ class AttentionBlock(JaxComponent):
         self.batch_size = batch_size
         self.seq_len = seq_len
         self.causal_mask = jnp.tril(jnp.ones((seq_len, seq_len), dtype=bool))
-        
+        self.position_encoding = position_encoding
+        self.use_rope = position_encoding == "rope"
+        self.rope_theta = rope_theta
+
         if self.n_embed % self.n_heads != 0:
             raise ValueError(f"n_embed={n_embed} must be divisible by n_heads={n_heads}")
         self.d_head = n_embed // n_heads
 
-        # Precompute RoPE
-        cos_rope, sin_rope = precompute_freqs_cis_real(self.d_head, self.seq_len)
+        if self.use_rope and self.d_head % 2 != 0:
+            raise ValueError(f"With RoPE, d_head={self.d_head} must be even for complex number representation.")
+        if self.use_rope:
+            # Precompute RoPE
+            cos_rope, sin_rope = precompute_freqs_cis_real(self.d_head, self.seq_len)
+        else:
+            cos_rope = jnp.ones((self.seq_len, self.d_head))
+            sin_rope = jnp.zeros((self.seq_len, self.d_head))
+        
         self.cos = Compartment(cos_rope)
         self.sin = Compartment(sin_rope)
 
@@ -170,10 +187,11 @@ class AttentionBlock(JaxComponent):
             self.dropout_rate, 
             self.seq_len,
             self.batch_size,  
+            self.use_rope,
             key                  
         )
         # self.S.set(S)
-        dq, dk, dv = compute_grads(q, k, v, cos, sin, mask, s_c, dmu, n_heads, d_head, dropout_rate, self.seq_len, self.batch_size, key)
+        dq, dk, dv = compute_grads(q, k, v, cos, sin, mask, s_c, dmu, n_heads, d_head, dropout_rate, self.seq_len, self.batch_size,self.use_rope, key)
         self.dq.set(dq)
         self.dk.set(dk)
         self.dv.set(dv)

--- a/utils/attention_utils.py
+++ b/utils/attention_utils.py
@@ -78,7 +78,7 @@ def compute_grads(Q_rot, K_rot, V, cos, sin, mask, s_c, dmu, n_heads, d_head, dr
     dQ_rot = jnp.einsum("bhqk,bhkd->bhqd", ds, K_rot)  # (B, H, S, D)
     dK_rot = jnp.einsum("bhkq,bhqd->bhkd", ds, Q_rot)  # (B, H, S, D)
     
-    # Inverse RoPE to get raw Q and K gradients
+    # Inverse RoPE to get raw Q and K gradients if use_rope = true
     if use_rope:
         dQ_raw, dK_raw = apply_rotary_emb_inv(dQ_rot, dK_rot, cos, sin)
     else:
@@ -116,6 +116,9 @@ class AttentionBlock(JaxComponent):
         seq_len: Sequence length
         dropout_rate: Attention dropout rate
         batch_size: Batch size
+        position_encoding: "rope" or "positional"
+        rope_theta: RoPE frequency base (used only when position_encoding="rope")
+        
     """
     
     def __init__(self, name, n_heads, n_embed, seq_len, dropout_rate, batch_size, position_encoding="rope", rope_theta=10000.0, **kwargs):

--- a/utils/attention_utils.py
+++ b/utils/attention_utils.py
@@ -11,7 +11,7 @@ from utils.rope_utils import apply_rotary_emb, apply_rotary_emb_inv, precompute_
 @partial(jit, static_argnums=[6, 7, 8, 9, 10,11])
 def _compute_attention(Q, K, V, cos, sin, mask, n_heads, d_head, dropout_rate, seq_len, batch_size, use_rope,  key):
     """
-    Compute multi-head attention with RoPE
+    Compute multi-head attention 
     """
     B = batch_size
     S = seq_len

--- a/utils/attention_utils.py
+++ b/utils/attention_utils.py
@@ -8,7 +8,7 @@ import jax.numpy as jnp
 from utils.model_util import d_softmax_vjp
 from utils.rope_utils import apply_rotary_emb, apply_rotary_emb_inv, precompute_freqs_cis_real
 
-@partial(jit, static_argnums=[6, 7, 8, 9, 10])
+@partial(jit, static_argnums=[6, 7, 8, 9, 10,11])
 def _compute_attention(Q, K, V, cos, sin, mask, n_heads, d_head, dropout_rate, seq_len, batch_size, use_rope,  key):
     """
     Compute multi-head attention with RoPE
@@ -53,7 +53,7 @@ def _compute_attention(Q, K, V, cos, sin, mask, n_heads, d_head, dropout_rate, s
     return attention, s_c, q_used, k_used, v
 
 
-@partial(jit, static_argnums=[8, 9, 10, 11, 12])
+@partial(jit, static_argnums=[8, 9, 10, 11, 12,13])
 def compute_grads(Q_rot, K_rot, V, cos, sin, mask, s_c, dmu, n_heads, d_head, dropout_rate, seq_len, batch_size,use_rope, key):
     """Compute gradients for Q, K, V using d_softmax and attention scores
     """
@@ -139,7 +139,7 @@ class AttentionBlock(JaxComponent):
             raise ValueError(f"With RoPE, d_head={self.d_head} must be even for complex number representation.")
         if self.use_rope:
             # Precompute RoPE
-            cos_rope, sin_rope = precompute_freqs_cis_real(self.d_head, self.seq_len)
+            cos_rope, sin_rope = precompute_freqs_cis_real(self.d_head, self.seq_len, theta= self.rope_theta)
         else:
             cos_rope = jnp.ones((self.seq_len, self.d_head))
             sin_rope = jnp.zeros((self.seq_len, self.d_head))

--- a/utils/embed_utils.py
+++ b/utils/embed_utils.py
@@ -26,8 +26,8 @@ def _create_sinusoidal_embeddings(seq_len, embed_dim):
     embeddings = embeddings.at[:, 1::2].set(jnp.cos(angles))
     return embeddings
 
-@partial(jit, static_argnums=[2, 3, 4, 5])
-def _compute_embedding_updates(inputs, post, vocab_size, seq_len, embed_dim, batch_size):
+@partial(jit, static_argnums=[2, 3, 4, 5, 6])
+def _compute_embedding_updates(inputs, post, vocab_size, seq_len, embed_dim, batch_size,pos_learnable):
     """
     Compute updates for word embeddings and positional embeddings
     """
@@ -47,7 +47,7 @@ def _compute_embedding_updates(inputs, post, vocab_size, seq_len, embed_dim, bat
     d_pos_weights = jnp.zeros((seq_len, embed_dim))
     
     batch_positions = jnp.tile(jnp.arange(seq_len), batch_size).astype(jnp.int32)
-    d_pos_weights =  d_pos_weights.at[batch_positions].add(flat_errors)
+    d_pos_weights =  jax.lax.cond(pos_learnable, lambda: d_pos_weights.at[batch_positions].add(flat_errors), lambda: d_pos_weights)
             
     return d_word_weights, d_pos_weights
 
@@ -100,9 +100,9 @@ class EmbeddingSynapse(JaxComponent):
         self.position_encoding = position_encoding
         self.use_positional = (self.position_encoding == "positional")
         self.pos_learnable = pos_learnable
-        #separate keys for word and positional embeddings
-        word_key =random.PRNGKey(1234)
-        pos_key = random.fold_in(word_key,1)
+        
+        key = random.PRNGKey(1234)
+        word_key, pos_key = random.split(key, 2)
         
         word_weights = random.normal(word_key, (vocab_size, embed_dim)) * weight_scale
         if self.use_positional:
@@ -178,11 +178,12 @@ class EmbeddingSynapse(JaxComponent):
         word_weights = self.word_weights.get()
         pos_weights = self.pos_weights.get()
         word_opt_params = self.word_opt_params.get()
+        pos_opt_params = self.pos_opt_params.get()
         
         # Compute embedding updates
         inputs= inputs.astype(jnp.int32)
         (d_word_weights, d_pos_weights)  = _compute_embedding_updates(
-            inputs, post, vocab_size, seq_len, embed_dim, batch_size
+            inputs, post, vocab_size, seq_len, embed_dim, batch_size, self.pos_learnable
         )
         
         word_opt_params, [new_word_weights] = opt(
@@ -193,13 +194,17 @@ class EmbeddingSynapse(JaxComponent):
         self.word_opt_params.set(word_opt_params)
         self.dWordWeights.set(d_word_weights)
 
+        new_pos_weights = pos_weights
+        new_pos_opt_params = pos_opt_params
+
         if (self.use_positional and self.pos_learnable):
-            pos_opt_params = self.pos_opt_params.get()
+            
             pos_opt_params, [new_pos_weights] = opt(
                 pos_opt_params, [pos_weights], [d_pos_weights]
             )
+            new_pos_opt_params = pos_opt_params
             self.pos_weights.set(new_pos_weights)
-            self.pos_opt_params.set(pos_opt_params)
+            self.pos_opt_params.set(new_pos_opt_params)
             self.dPosWeights.set(d_pos_weights)
         else:
             #fixed sinusoidal positions and RoPE 

--- a/utils/embed_utils.py
+++ b/utils/embed_utils.py
@@ -9,10 +9,27 @@ from ngclearn.utils import tensorstats
 import os
 from pathlib import Path
 
+@partial(jit, static_argnums=[0,1])
+def _create_sinusoidal_embeddings(seq_len, embed_dim):
+    """
+    Create fixed absolute sinusoidal positional embeddings.
+
+    Returns:
+        Shape: (seq_len, embed_dim)
+    """
+    position = jnp.arange(seq_len)[:, None]
+    div_term = jnp.exp(jnp.arange(0, embed_dim, 2) * 
+                      (-jnp.log(10000.0) / embed_dim))
+    angles = position * div_term
+    embeddings = jnp.zeros((seq_len, embed_dim))
+    embeddings = embeddings.at[:, 0::2].set(jnp.sin(angles))
+    embeddings = embeddings.at[:, 1::2].set(jnp.cos(angles))
+    return embeddings
+
 @partial(jit, static_argnums=[2, 3, 4, 5])
 def _compute_embedding_updates(inputs, post, vocab_size, seq_len, embed_dim, batch_size):
     """
-    Compute updates for word embeddings
+    Compute updates for word embeddings and postional embeddings
     """
     
     # Flatten for processing
@@ -23,8 +40,18 @@ def _compute_embedding_updates(inputs, post, vocab_size, seq_len, embed_dim, bat
     d_word_weights = jnp.zeros((vocab_size, embed_dim))
     
     d_word_weights = d_word_weights.at[flat_tokens].add(flat_errors)
+
+
+    # postional embededings update
+
+    d_pos_weights = jnp.zeros((seq_len, embed_dim))
+    
+    batch_positions = jnp.tile(jnp.arange(seq_len), batch_size).astype(jnp.int32)
+    d_pos_weights = jax.lax.cond(
+      lambda: d_pos_weights.at[batch_positions].add(flat_errors), lambda: d_pos_weights
+    )
             
-    return d_word_weights
+    return d_word_weights, d_pos_weights
 
 class EmbeddingSynapse(JaxComponent):
     """
@@ -60,7 +87,7 @@ class EmbeddingSynapse(JaxComponent):
 
     def __init__(
             self, name, vocab_size, seq_len, embed_dim, batch_size,
-            eta, optim_type, weight_scale=0.02,
+            eta, optim_type,position_encoding="rope", pos_learnable=True, weight_scale=0.02,
             **kwargs
     ):
         super().__init__(name, **kwargs)
@@ -72,23 +99,44 @@ class EmbeddingSynapse(JaxComponent):
         self.eta = eta
         self.weight_scale = weight_scale
         self.optim_type = optim_type
-
-        key =random.PRNGKey(1234)
-        word_weights = random.normal(key, (vocab_size, embed_dim)) * weight_scale
-
+        self.position_encoding = position_encoding
+        self.use_postional = (self.position_encoding == "positional")
+        self.pos_learnable = pos_learnable
+        #separate keys for word and positional embeddings
+        word_key =random.PRNGKey(1234)
+        pos_key = random.fold_in(word_key,1)
+        
+        word_weights = random.normal(word_key, (vocab_size, embed_dim)) * weight_scale
+        if self.use_postional:
+            if self.pos_learnable:
+                pos_weights = random.normal(pos_key, (seq_len, embed_dim)) * weight_scale
+            else:
+                pos_weights = _create_sinusoidal_embeddings(seq_len, embed_dim)
+        else:
+            # unused in RopE mode
+            pos_weights = jnp.zeros((seq_len, embed_dim))
+        
         ## Compartments
         self.inputs = Compartment(jnp.zeros((batch_size, seq_len), dtype=jnp.int32))
         self.outputs = Compartment(jnp.zeros((batch_size, seq_len, embed_dim)))
         self.word_weights = Compartment(word_weights)
+        self.pos_weights = Compartment(pos_weights)
         self.post = Compartment(jnp.zeros((batch_size, seq_len, embed_dim)))
         
         self.dWordWeights = Compartment(jnp.zeros((vocab_size, embed_dim)))
-        
+        self.dPosWeights = Compartment(jnp.zeros((seq_len, embed_dim)))
         # Optimization
         self.opt = get_opt_step_fn(optim_type, eta=self.eta)
         self.word_opt_params = Compartment(
             get_opt_init_fn(optim_type)([self.word_weights.get()])
         )
+        #postion optimizer for learned only
+        if(self.use_postional and self.pos_learnable):
+            self.pos_opt_params = Compartment(
+                get_opt_init_fn(optim_type)([self.pos_weights.get()])
+            )
+        else:
+            self.pos_opt_params = Compartment(None)
     @compilable
     def advance_state(self):
         """
@@ -104,13 +152,23 @@ class EmbeddingSynapse(JaxComponent):
         word_embeds_flat = word_weights[flat_tokens]
         word_embeds = word_embeds_flat.reshape(batch_size, seq_len, embed_dim)
         
-        self.outputs.set(word_embeds)
+        if self.use_postional:
+            pos_weights = self.pos_weights.get()
+            positions = jnp.arange(seq_len)
+            pos_embeds= pos_weights[positions]
+            pos_embeds_batch = jnp.broadcast_to(pos_embeds, (batch_size, seq_len, embed_dim))
+
+            outputs = (word_embeds +pos_embeds_batch)
+        else:
+            #RoPE mode
+            outputs = word_embeds
+        self.outputs.set(outputs)
 
   
     @compilable
     def evolve(self):
         """
-        Learning step: Hebbian updates for word embeddings
+        Learning step: Hebbian updates for word embeddings and update postional embeddings only when using learned absolute postional embeddings
         """
         opt = self.opt.get()
         vocab_size = self.vocab_size.get()
@@ -120,11 +178,12 @@ class EmbeddingSynapse(JaxComponent):
         inputs = self.inputs.get()
         post = self.post.get()
         word_weights = self.word_weights.get()
+        pos_weights = self.pos_weights.get()
         word_opt_params = self.word_opt_params.get()
-
+        
         # Compute embedding updates
         inputs= inputs.astype(jnp.int32)
-        d_word_weights = _compute_embedding_updates(
+        (d_word_weights, d_pos_weights)  = _compute_embedding_updates(
             inputs, post, vocab_size, seq_len, embed_dim, batch_size
         )
         
@@ -133,8 +192,21 @@ class EmbeddingSynapse(JaxComponent):
         )
         
         self.word_weights.set(new_word_weights)
-        self.dWordWeights.set(d_word_weights)
         self.word_opt_params.set(word_opt_params)
+        self.dWordWeights.set(d_word_weights)
+
+        if (self.use_postional and self.pos_learnable):
+            pos_opt_params = self.pos_opt_params.get()
+            pos_opt_params, [new_pos_weights] = opt(
+                pos_opt_params, [pos_weights], [d_pos_weights]
+            )
+            self.pos_weights.set(new_pos_weights)
+            self.pos_opt_params.set(pos_opt_params)
+            self.dPosWeights.set(d_pos_weights)
+        else:
+            #fixed sinusoidal postions and RoPE 
+            self.dPosWeights.set(jnp.zeros_like(pos_weights))
+        
     @compilable
     def reset(self):
         """
@@ -149,11 +221,12 @@ class EmbeddingSynapse(JaxComponent):
         outputs = jnp.zeros((batch_size, seq_len, embed_dim))
         post = jnp.zeros((batch_size, seq_len, embed_dim))
         dWordWeights = jnp.zeros((vocab_size, embed_dim))
-        
+        dPosWeights = jnp.zeros((seq_len, embed_dim))
         self.inputs.set(inputs)
         self.outputs.set(outputs)
         self.post.set(post)
         self.dWordWeights.set(dWordWeights)
+        self.dPosWeights.set(dPosWeights)
 
 
     @classmethod
@@ -219,15 +292,22 @@ class EmbeddingSynapse(JaxComponent):
 
 
     def save(self, directory, **kwargs):
-        """Save word embedding parameters to disk."""
+        """Save word embedding parameters and learned positional embedding parameters to disk."""
         
         Path(directory).mkdir(parents=True, exist_ok=True)
         file_name = os.path.join(directory, f"{self.name}.npz")
         
-        jnp.savez(
-            file_name,
-            word_weights=self.word_weights.get()
-        )
+        if (self.use_positional and self.pos_learnable):
+            jnp.savez(
+                file_name,
+                word_weights=(self.word_weights.get()),
+                pos_weights=(self.pos_weights.get()),
+            )
+        else:
+            jnp.savez(
+                file_name,
+                word_weights=( self.word_weights.get()),
+            )
       
 
     def load(self, directory, **kwargs):
@@ -237,3 +317,15 @@ class EmbeddingSynapse(JaxComponent):
         data = jnp.load(file_name)
         
         self.word_weights.set(data['word_weights'])
+
+        if (self.use_positional and self.pos_learnable ):
+            if "pos_weights" not in data:
+                raise ValueError(
+                    "The checkpoint has no "
+                    "pos_weights. It may have "
+                    "been trained using RoPE."
+                )
+
+            self.pos_weights.set(
+                data["pos_weights"]
+            )

--- a/utils/embed_utils.py
+++ b/utils/embed_utils.py
@@ -29,7 +29,7 @@ def _create_sinusoidal_embeddings(seq_len, embed_dim):
 @partial(jit, static_argnums=[2, 3, 4, 5])
 def _compute_embedding_updates(inputs, post, vocab_size, seq_len, embed_dim, batch_size):
     """
-    Compute updates for word embeddings and postional embeddings
+    Compute updates for word embeddings and positional embeddings
     """
     
     # Flatten for processing
@@ -42,14 +42,12 @@ def _compute_embedding_updates(inputs, post, vocab_size, seq_len, embed_dim, bat
     d_word_weights = d_word_weights.at[flat_tokens].add(flat_errors)
 
 
-    # postional embededings update
+    # positional embededings update
 
     d_pos_weights = jnp.zeros((seq_len, embed_dim))
     
     batch_positions = jnp.tile(jnp.arange(seq_len), batch_size).astype(jnp.int32)
-    d_pos_weights = jax.lax.cond(
-      lambda: d_pos_weights.at[batch_positions].add(flat_errors), lambda: d_pos_weights
-    )
+    d_pos_weights =  d_pos_weights.at[batch_positions].add(flat_errors)
             
     return d_word_weights, d_pos_weights
 
@@ -168,7 +166,7 @@ class EmbeddingSynapse(JaxComponent):
     @compilable
     def evolve(self):
         """
-        Learning step: Hebbian updates for word embeddings and update postional embeddings only when using learned absolute postional embeddings
+        Learning step: Hebbian updates for word embeddings and update positional embeddings only when using learned absolute positional embeddings
         """
         opt = self.opt.get()
         vocab_size = self.vocab_size.get()
@@ -204,7 +202,7 @@ class EmbeddingSynapse(JaxComponent):
             self.pos_opt_params.set(pos_opt_params)
             self.dPosWeights.set(d_pos_weights)
         else:
-            #fixed sinusoidal postions and RoPE 
+            #fixed sinusoidal positions and RoPE 
             self.dPosWeights.set(jnp.zeros_like(pos_weights))
         
     @compilable

--- a/utils/embed_utils.py
+++ b/utils/embed_utils.py
@@ -229,36 +229,100 @@ class EmbeddingSynapse(JaxComponent):
 
     @classmethod
     def help(cls):
-        """Component help function"""
+        """
+        Return metadata describing the embedding component.
+
+        EmbeddingSynapse supports two position-encoding configurations:
+
+        - rope: returns word embeddings only. RoPE is applied later to
+        the query and key tensors in the attention component.
+        - positional: adds learned or fixed absolute positional
+        embeddings to the word embeddings.
+        """
         properties = {
-            "synapse_type": "EmbeddingSynapse - returns a single word embedding representation"
-        }
+            "synapse_type": (
+                "EmbeddingSynapse - performs token embedding lookup and "
+                "optionally adds absolute positional embeddings. In RoPE "
+                "mode, rotation is applied later to attention queries and keys."
+            )
+            }
+
         compartment_props = {
-            "inputs": 
-                {"inputs": "Input token indices (batch_size, seq_len)",
-                 "post": "Post-synaptic error signals for learning"},
-            "states":
-                {"word_weights": "Word embedding matrix (vocab_size, embed_dim)",
-                 "key": "JAX PRNG key"},
-            "analytics":
-                {"dWordWeights": "Word embedding adjustment matrix"},
-            "outputs":
-                {"outputs": "Embeddings (batch_size, seq_len, embed_dim)"},
+            "inputs": {
+                "inputs": (
+                    "Input token indices "
+                    "(batch_size, seq_len)"
+                ),
+                "post": (
+                    "Post-synaptic error signals used for learning "
+                    "(batch_size, seq_len, embed_dim)"
+                ),
+            },
+            "states": {
+                "word_weights": (
+                    "Word embedding matrix "
+                    "(vocab_size, embed_dim)"
+                ),
+                "pos_weights": (
+                    "Absolute positional embedding matrix "
+                    "(seq_len, embed_dim); used only in positional mode"
+                ),
+                "word_opt_params": (
+                    "Optimizer state for the word embedding matrix"
+                ),
+                "pos_opt_params": (
+                    "Optimizer state for learned positional embeddings; "
+                    "inactive in RoPE and fixed positional modes"
+                ),
+            },
+            "analytics": {
+                "dWordWeights": (
+                    "Word embedding update matrix "
+                    "(vocab_size, embed_dim)"
+                ),
+                "dPosWeights": (
+                    "Positional embedding update matrix "
+                    "(seq_len, embed_dim); zero unless learned "
+                    "positional embeddings are enabled"
+                ),
+            },
+            "outputs": {
+                "outputs": (
+                    "Embedding output "
+                    "(batch_size, seq_len, embed_dim)"
+                ),
+            },
         }
+
         hyperparams = {
-            "vocab_size": "Size of vocabulary",
-            "seq_len": "Maximum sequence length", 
-            "embed_dim": "Dimensionality of embeddings",
+            "vocab_size": "Size of the token vocabulary",
+            "seq_len": "Maximum input sequence length",
+            "embed_dim": "Dimensionality of each embedding",
             "batch_size": "Batch size dimension",
-            "eta": "Global learning rate",
-            "optim_type": "Optimization scheme",
-            "weight_scale": "Weight initialization scale"
+            "position_encoding": (
+                "Position-encoding mode: 'rope' or 'positional'"
+            ),
+            "pos_learnable": (
+                "Whether absolute positional embeddings are trainable; "
+                "used only when position_encoding='positional'"
+            ),
+            "eta": "Optimizer learning rate",
+            "optim_type": "Optimization algorithm",
+            "weight_scale": "Embedding initialization scale",
         }
-        info = {cls.__name__: properties,
-                "compartments": compartment_props,
-                "dynamics": "outputs = word_embedding[inputs]",
-                "hyperparameters": hyperparams}
-        return info
+
+        info = {
+            cls.__name__: properties,
+            "compartments": compartment_props,
+            "dynamics": (
+                "rope: outputs = word_embedding[inputs]; "
+                "positional: outputs = word_embedding[inputs] + "
+                "position_embedding[positions]"
+            ),
+            "hyperparameters": hyperparams,
+        }
+
+        return info    
     def __repr__(self):
         # FIX: Replaced the non-existent Compartment.is_compartment with isinstance(..., Compartment)
         comps = [varname for varname in dir(self) if isinstance(getattr(self, varname), Compartment)]
@@ -274,15 +338,38 @@ class EmbeddingSynapse(JaxComponent):
         for c in comps:
             # Get the actual Compartment object
             compartment_obj = getattr(self, c) 
+            compartment_value = compartment_obj.get()
             
-            # Get tensor statistics (assuming tensorstats is correctly imported)
-            stats = tensorstats(compartment_obj.get())
-            
-            if stats is not None:
-                line = [f"{k}: {v}" for k, v in stats.items()]
-                line = ", ".join(line)
-            else:
+            # This check is necessary because pos_opt_params contains None
+            # in RoPE mode and fixed positional-embedding mode.
+            # tensorstats() should not be called on None.
+            if compartment_value is None:
                 line = "None"
+
+            else:
+                try:
+                    # Get tensor statistics (assuming tensorstats is correctly imported)
+                    stats = tensorstats(compartment_value)
+
+                except (TypeError, ValueError, AttributeError):
+                    # Optimizer-state compartments may contain lists,
+                    # tuples, or other nested structures instead of one
+                    # tensor. Represent their type without changing them.
+                    stats = None
+                    line = (
+                        f"type: "
+                        f"{type(compartment_value).__name__}"
+                    )
+
+                else:
+                    if stats is not None:
+                        line = [
+                            f"{k}: {v}"
+                            for k, v in stats.items()
+                        ]
+                        line = ", ".join(line)
+                    else:
+                        line = "None"
                 
             lines += f"  {f'({c})'.ljust(maxlen)}{line}\n"
             

--- a/utils/embed_utils.py
+++ b/utils/embed_utils.py
@@ -53,17 +53,20 @@ def _compute_embedding_updates(inputs, post, vocab_size, seq_len, embed_dim, bat
 
 class EmbeddingSynapse(JaxComponent):
     """
-    A synaptic cable that handles word embeddings.
+    A synaptic cable that handles word and positional embeddings.
 
     | --- Synapse Compartments: ---
     | inputs - input token indices (takes in external signals)
     | outputs - output embedding signals (only word embeddings)
     | word_weights - word embedding matrix
+    | pos_weights - position embedding matrix  
     | post - post-synaptic signals for learning (takes in external signals)
     | key - JAX PRNG key
     | --- Synaptic Plasticity Compartments: ---
     | dWordWeights - current delta matrix for word embedding changes
+    | dPosWeights - current delta matrix for position embedding changes
     | word_opt_params - optimizer statistics for word embeddings
+    | pos_opt_params - optimizer statistics for position embeddings
 
     Args:
         name: the string name of this component
@@ -80,12 +83,16 @@ class EmbeddingSynapse(JaxComponent):
 
         optim_type: optimization scheme (Default: "sgd")
 
+        pos_learnable: whether position embeddings are learnable or fixed
+
+        position_encoding: type of position encoding (Default: "rope")
+
         weight_scale: scaling factor for weight initialization (Default: 0.02)
     """
 
     def __init__(
             self, name, vocab_size, seq_len, embed_dim, batch_size,
-            eta, optim_type,position_encoding="rope", pos_learnable=True, weight_scale=0.02,
+            eta, optim_type,position_encoding="rope", pos_learnable=False, weight_scale=0.02,
             **kwargs
     ):
         super().__init__(name, **kwargs)
@@ -138,7 +145,7 @@ class EmbeddingSynapse(JaxComponent):
     @compilable
     def advance_state(self):
         """
-        Forward pass: output = word_embedding[inputs]
+        Forward pass: output = word_embedding[inputs] + position_embedding[positions]
         """
         inputs=self.inputs.get()
         word_weights=self.word_weights.get()
@@ -156,11 +163,11 @@ class EmbeddingSynapse(JaxComponent):
             pos_embeds= pos_weights[positions]
             pos_embeds_batch = jnp.broadcast_to(pos_embeds, (batch_size, seq_len, embed_dim))
 
-            outputs = (word_embeds +pos_embeds_batch)
+            combined_embeddings = word_embeds + pos_embeds_batch
         else:
             #RoPE mode
-            outputs = word_embeds
-        self.outputs.set(outputs)
+            combined_embeddings = word_embeds
+        self.outputs.set(combined_embeddings)
 
   
     @compilable
@@ -225,6 +232,7 @@ class EmbeddingSynapse(JaxComponent):
         post = jnp.zeros((batch_size, seq_len, embed_dim))
         dWordWeights = jnp.zeros((vocab_size, embed_dim))
         dPosWeights = jnp.zeros((seq_len, embed_dim))
+        # return inputs, outputs, post, dWordWeights, dPosWeights
         self.inputs.set(inputs)
         self.outputs.set(outputs)
         self.post.set(post)

--- a/utils/embed_utils.py
+++ b/utils/embed_utils.py
@@ -100,14 +100,14 @@ class EmbeddingSynapse(JaxComponent):
         self.weight_scale = weight_scale
         self.optim_type = optim_type
         self.position_encoding = position_encoding
-        self.use_postional = (self.position_encoding == "positional")
+        self.use_positional = (self.position_encoding == "positional")
         self.pos_learnable = pos_learnable
         #separate keys for word and positional embeddings
         word_key =random.PRNGKey(1234)
         pos_key = random.fold_in(word_key,1)
         
         word_weights = random.normal(word_key, (vocab_size, embed_dim)) * weight_scale
-        if self.use_postional:
+        if self.use_positional:
             if self.pos_learnable:
                 pos_weights = random.normal(pos_key, (seq_len, embed_dim)) * weight_scale
             else:
@@ -130,8 +130,8 @@ class EmbeddingSynapse(JaxComponent):
         self.word_opt_params = Compartment(
             get_opt_init_fn(optim_type)([self.word_weights.get()])
         )
-        #postion optimizer for learned only
-        if(self.use_postional and self.pos_learnable):
+        #position optimizer for learned only
+        if(self.use_positional and self.pos_learnable):
             self.pos_opt_params = Compartment(
                 get_opt_init_fn(optim_type)([self.pos_weights.get()])
             )
@@ -152,7 +152,7 @@ class EmbeddingSynapse(JaxComponent):
         word_embeds_flat = word_weights[flat_tokens]
         word_embeds = word_embeds_flat.reshape(batch_size, seq_len, embed_dim)
         
-        if self.use_postional:
+        if self.use_positional:
             pos_weights = self.pos_weights.get()
             positions = jnp.arange(seq_len)
             pos_embeds= pos_weights[positions]
@@ -195,7 +195,7 @@ class EmbeddingSynapse(JaxComponent):
         self.word_opt_params.set(word_opt_params)
         self.dWordWeights.set(d_word_weights)
 
-        if (self.use_postional and self.pos_learnable):
+        if (self.use_positional and self.pos_learnable):
             pos_opt_params = self.pos_opt_params.get()
             pos_opt_params, [new_pos_weights] = opt(
                 pos_opt_params, [pos_weights], [d_pos_weights]

--- a/utils/embed_utils.py
+++ b/utils/embed_utils.py
@@ -20,10 +20,10 @@ def _create_sinusoidal_embeddings(seq_len, embed_dim):
     position = jnp.arange(seq_len)[:, None]
     div_term = jnp.exp(jnp.arange(0, embed_dim, 2) * 
                       (-jnp.log(10000.0) / embed_dim))
-    angles = position * div_term
+    
     embeddings = jnp.zeros((seq_len, embed_dim))
-    embeddings = embeddings.at[:, 0::2].set(jnp.sin(angles))
-    embeddings = embeddings.at[:, 1::2].set(jnp.cos(angles))
+    embeddings = embeddings.at[:, 0::2].set(jnp.sin(position * div_term))
+    embeddings = embeddings.at[:, 1::2].set(jnp.cos(position * div_term))
     return embeddings
 
 @partial(jit, static_argnums=[2, 3, 4, 5, 6])


### PR DESCRIPTION
**Summary** 

This PR adds support for selecting the positional embedding type through the configuration. The model can now use either RoPE or learned positional embeddings by changing a configuration option.

**Changes**

  -  Added a configuration option to choose the embedding type (rope or positional).
  -  Restored the learned positional embedding implementation alongside the existing RoPE implementation.
  -  Updated the model initialization to instantiate the appropriate positional embedding based on the configuration.
  -  Ensured both embedding methods are supported without requiring code changes