### PR TITLE
Add weight bounding, regularization prior, and configurable weight initialization to EmbeddingSynapse

### DIFF
--- a/layers/embedding.py
+++ b/layers/embedding.py
@@ -29,7 +29,7 @@ class EMBEDDING:
                 w_bound=1.,
                 is_nonnegative=False,
                 prior=("constant", 0.),
-                weight_init=dist.fan_in_gaussian(),
+                weight_init=dist.constant(value=0.0),  # Initialize weights to zero
                 key=subkeys[0])
             
         self.e_embed = ErrorCell("e_embed", n_units=embed_dim, 

--- a/layers/embedding.py
+++ b/layers/embedding.py
@@ -29,6 +29,7 @@ class EMBEDDING:
                 w_bound=1.,
                 is_nonnegative=False,
                 prior=("constant", 0.),
+                weight_init=dist.fan_in_gaussian(),
                 key=subkeys[0])
             
         self.e_embed = ErrorCell("e_embed", n_units=embed_dim, 

--- a/layers/embedding.py
+++ b/layers/embedding.py
@@ -1,4 +1,3 @@
-
 from utils.errorcell import GaussianErrorCell as ErrorCell
 from utils.ratecell import RateCell
 from ngclearn.utils.distribution_generator import DistributionGenerator as dist
@@ -27,10 +26,10 @@ class EMBEDDING:
                 pos_learnable=pos_learnable,
                 eta=eta,
                 optim_type=optim_type,
+                w_bound=1.,
+                is_nonnegative=False,
+                prior=("constant", 0.),
                 key=subkeys[0])
             
         self.e_embed = ErrorCell("e_embed", n_units=embed_dim, 
                                   batch_size=batch_size * seq_len) # shape=(seq_len, embed_dim, 1),
-    
-            
-

--- a/layers/embedding.py
+++ b/layers/embedding.py
@@ -29,7 +29,7 @@ class EMBEDDING:
                 w_bound=1.,
                 is_nonnegative=False,
                 prior=("constant", 0.),
-                weight_init=dist.constant(value=0.0),  # Initialize weights to zero
+                weight_init=dist.fan_in_gaussian(),
                 key=subkeys[0])
             
         self.e_embed = ErrorCell("e_embed", n_units=embed_dim, 

--- a/model.py
+++ b/model.py
@@ -593,7 +593,7 @@ class NGCTransformer:
 
         # ══════  Learning  ═════════════════════════════════════════
         EFE = 0.            ## expected free energy
-        
+        y_mu = jnp.zeros((self.batch_size * self.seq_len, self.vocab_size))  ## settled prediction
         if adapt_synapses:
             ## ════════════════════════════════
             ## Perform several E-steps

--- a/model.py
+++ b/model.py
@@ -592,42 +592,37 @@ class NGCTransformer:
         self.output.e_out.dtarget.set(self.projection.eq_target.dtarget.get())
 
         # ══════  Learning  ═════════════════════════════════════════
-        EFE = 0.            ## expected free energy
-        y_mu = 0.           ## initial prediction
+        ## ════════════════════════════════
+        ## Perform several E-steps -- always run, regardless of adapt_synapses
+        for ts in range(0, self.T):
+            self.clamp_input(obs)
+            self.clamp_target(lab)
+            self.advance.run(t=ts, dt=1.)
+
+        ## ════════════════════════════════
+        ## get settled prediction
+        y_mu = self.z_actfx.zF.get()
+
+        ## calculate approximate EFE
+        L1 = self.embedding.e_embed.L.get()
+        L4 = self.output.e_out.L.get()
+        block_errors = 0.
+        for i in range(self.n_layers):
+            block = self.blocks[i]
+            block_errors += (block.attention.e_attn.L.get() + 
+                             block.attention.e_qkv.L.get()
+                             + block.mlp.e_mlp.L.get()
+                             + block.mlp.e_mlp1.L.get()
+                             )
+
+        EFE = L1 + block_errors + L4
+
+        ## ════════════════════════════════
+        ## Perform M-step -- only if training
         if adapt_synapses:
-            ## ════════════════════════════════
-            ## Perform several E-steps
-            for ts in range(0, self.T):
-                self.clamp_input(obs)
-                self.clamp_target(lab)
-                self.advance.run(t=ts, dt=1.)
+            self.embedding_evolve.run()
+            self.evolve.run(t=self.T, dt=1.)
 
-            ## ════════════════════════════════
-            ## get settled prediction
-            y_mu = self.z_actfx.zF.get()
-
-            ## calculate approximate EFE
-            L1 = self.embedding.e_embed.L.get()
-            L4 = self.output.e_out.L.get()
-            block_errors = 0.
-            for i in range(self.n_layers):
-                block = self.blocks[i]
-                block_errors += (block.attention.e_attn.L.get() + 
-                                 block.attention.e_qkv.L.get()
-                                 + block.mlp.e_mlp.L.get()
-                                 + block.mlp.e_mlp1.L.get()
-                                 )
-
-            EFE = L1 + block_errors + L4
-
-            ## ════════════════════════════════
-            ## Perform M-step
-            if adapt_synapses == True:
-                self.embedding_evolve.run()
-                self.evolve.run(t=self.T, dt=1.)
-
-        ##################################################
-        ## skip E/M steps if just doing test-time inference
         return y_mu_inf, y_mu, EFE
 
     def count_parameters(self):

--- a/model.py
+++ b/model.py
@@ -592,37 +592,42 @@ class NGCTransformer:
         self.output.e_out.dtarget.set(self.projection.eq_target.dtarget.get())
 
         # ══════  Learning  ═════════════════════════════════════════
-        ## ════════════════════════════════
-        ## Perform several E-steps -- always run, regardless of adapt_synapses
-        for ts in range(0, self.T):
-            self.clamp_input(obs)
-            self.clamp_target(lab)
-            self.advance.run(t=ts, dt=1.)
-
-        ## ════════════════════════════════
-        ## get settled prediction
-        y_mu = self.z_actfx.zF.get()
-
-        ## calculate approximate EFE
-        L1 = self.embedding.e_embed.L.get()
-        L4 = self.output.e_out.L.get()
-        block_errors = 0.
-        for i in range(self.n_layers):
-            block = self.blocks[i]
-            block_errors += (block.attention.e_attn.L.get() + 
-                             block.attention.e_qkv.L.get()
-                             + block.mlp.e_mlp.L.get()
-                             + block.mlp.e_mlp1.L.get()
-                             )
-
-        EFE = L1 + block_errors + L4
-
-        ## ════════════════════════════════
-        ## Perform M-step -- only if training
+        EFE = 0.            ## expected free energy
+        
         if adapt_synapses:
-            self.embedding_evolve.run()
-            self.evolve.run(t=self.T, dt=1.)
+            ## ════════════════════════════════
+            ## Perform several E-steps
+            for ts in range(0, self.T):
+                self.clamp_input(obs)
+                self.clamp_target(lab)
+                self.advance.run(t=ts, dt=1.)
 
+            ## ════════════════════════════════
+            ## get settled prediction
+            y_mu = self.z_actfx.zF.get()
+
+            ## calculate approximate EFE
+            L1 = self.embedding.e_embed.L.get()
+            L4 = self.output.e_out.L.get()
+            block_errors = 0.
+            for i in range(self.n_layers):
+                block = self.blocks[i]
+                block_errors += (block.attention.e_attn.L.get() + 
+                                 block.attention.e_qkv.L.get()
+                                 + block.mlp.e_mlp.L.get()
+                                 + block.mlp.e_mlp1.L.get()
+                                 )
+
+            EFE = L1 + block_errors + L4
+
+            ## ════════════════════════════════
+            ## Perform M-step
+            if adapt_synapses == True:
+                self.embedding_evolve.run()
+                self.evolve.run(t=self.T, dt=1.)
+
+        ##################################################
+        ## skip E/M steps if just doing test-time inference
         return y_mu_inf, y_mu, EFE
 
     def count_parameters(self):

--- a/utils/embed_utils.py
+++ b/utils/embed_utils.py
@@ -133,19 +133,18 @@ class EmbeddingSynapse(JaxComponent):
             default], ("l2"/"ridge", lmbda), ("l1"/"lasso", lmbda),
             ("l1l2"/"elastic_net", (scale, l1_ratio))
 
-        weight_init: a kernel (shape, key) -> array used to sample
-            word_weights/pos_weights; if None (default), falls back to the
-            existing random.normal(...) * weight_scale initialization.
-            Note: for a (vocab_size, embed_dim) shape, kernels such as
-            ngclearn's dist.fan_in_gaussian() treat fan_in = vocab_size,
-            not embed_dim, since fan_in is always read from shape[0].
+       weight_init: initialization kernel (shape, key) -> array used to
+            initialize word_weights and learnable pos_weights.
+            Default follows initialization strategy as:
+            dist.constant(value=0.0).
+            Random initialization can be supplied if desired.
     """
 
     def __init__(
             self, name, vocab_size, seq_len, embed_dim, batch_size,
             pos_learnable, eta, optim_type, weight_scale=0.02, sign_value=-1.,
             w_bound=1., is_nonnegative=False, prior=("constant", 0.),
-            weight_init=dist.fan_in_gaussian(),
+            weight_init=dist.constant(value=0.0),
             **kwargs
     ):
         super().__init__(name, **kwargs)

--- a/utils/embed_utils.py
+++ b/utils/embed_utils.py
@@ -6,6 +6,7 @@ from ngclearn.components.jaxComponent import JaxComponent
 from ngclearn import Compartment
 from ngclearn import compilable
 from ngclearn.utils import tensorstats
+from ngclearn.utils.distribution_generator import DistributionGenerator as dist
 import os
 from pathlib import Path
 
@@ -21,9 +22,29 @@ def _create_sinusoidal_embeddings(seq_len, embed_dim):
     embeddings = embeddings.at[:, 1::2].set(jnp.cos(position * div_term))
     return embeddings
 
-@partial(jit, static_argnums=[4, 5, 6, 7])
+@partial(jit, static_argnums=[1])
+def _calc_prior_term(weights, prior_type, prior_lmbda):
+    """
+    Computes an L1/L2/Elastic-Net regularization term to be added to an
+    embedding update before the optimizer step. Returns zeros if disabled.
+    """
+    dW_reg = jnp.zeros_like(weights)
+
+    if prior_type == "l2" or prior_type == "ridge":
+        dW_reg = -weights * prior_lmbda
+    elif prior_type == "l1" or prior_type == "lasso":
+        dW_reg = -jnp.sign(weights) * prior_lmbda
+    elif prior_type == "l1l2" or prior_type == "elastic_net":
+        prior_scale, l1_ratio = prior_lmbda
+        dW_reg = -jnp.sign(weights) * l1_ratio - weights * (1 - l1_ratio) / 2
+        dW_reg = dW_reg * prior_scale
+
+    return dW_reg
+
+@partial(jit, static_argnums=[4, 5, 6, 7, 9])
 def _compute_embedding_updates(inputs, post, word_weights, pos_weights, 
-                              vocab_size, seq_len, embed_dim, batch_size, pos_learnable):
+                              vocab_size, seq_len, embed_dim, batch_size, pos_learnable,
+                              prior_type, prior_lmbda):
     """
     Compute updates for word and position embeddings
     """
@@ -43,8 +64,26 @@ def _compute_embedding_updates(inputs, post, word_weights, pos_weights,
     d_pos_weights = jax.lax.cond(
     pos_learnable, lambda: d_pos_weights.at[batch_positions].add(flat_errors), lambda: d_pos_weights
     )
+
+    # Add regularization/prior term
+    d_word_weights = d_word_weights + _calc_prior_term(word_weights, prior_type, prior_lmbda)
+    d_pos_weights = d_pos_weights + _calc_prior_term(pos_weights, prior_type, prior_lmbda)
             
     return d_word_weights, d_pos_weights
+
+@partial(jit, static_argnums=[1, 2])
+def _enforce_constraints(weights, w_bound, is_nonnegative=False):
+    """
+    Applies a hard clip to weights after the optimizer step.
+    w_bound <= 0 disables clipping.
+    """
+    _W = weights
+    if w_bound > 0.:
+        if is_nonnegative:
+            _W = jnp.clip(_W, 0., w_bound)
+        else:
+            _W = jnp.clip(_W, -w_bound, w_bound)
+    return _W
 
 class EmbeddingSynapse(JaxComponent):
     """
@@ -82,11 +121,31 @@ class EmbeddingSynapse(JaxComponent):
         optim_type: optimization scheme (Default: "sgd")
 
         weight_scale: scaling factor for weight initialization (Default: 0.02)
+
+        w_bound: maximum absolute value to hard-clip word_weights/pos_weights
+            to after each evolve() step; <= 0 disables clipping (Default: 0.)
+
+        is_nonnegative: if True and w_bound > 0, clip to [0, w_bound] instead
+            of [-w_bound, w_bound] (Default: False)
+
+        prior: regularization prior applied to both word_weights and
+            pos_weights; tuple of (name, lambda): ("constant", 0.) [off,
+            default], ("l2"/"ridge", lmbda), ("l1"/"lasso", lmbda),
+            ("l1l2"/"elastic_net", (scale, l1_ratio))
+
+        weight_init: a kernel (shape, key) -> array used to sample
+            word_weights/pos_weights; if None (default), falls back to the
+            existing random.normal(...) * weight_scale initialization.
+            Note: for a (vocab_size, embed_dim) shape, kernels such as
+            ngclearn's dist.fan_in_gaussian() treat fan_in = vocab_size,
+            not embed_dim, since fan_in is always read from shape[0].
     """
 
     def __init__(
             self, name, vocab_size, seq_len, embed_dim, batch_size,
             pos_learnable, eta, optim_type, weight_scale=0.02, sign_value=-1.,
+            w_bound=1., is_nonnegative=False, prior=("constant", 0.),
+            weight_init=dist.fan_in_gaussian(),
             **kwargs
     ):
         super().__init__(name, **kwargs)
@@ -101,13 +160,34 @@ class EmbeddingSynapse(JaxComponent):
         self.optim_type = optim_type
         self.sign_value = sign_value
 
+        # Regularization/bounding configuration
+        self.w_bound = w_bound
+        self.is_nonnegative = is_nonnegative
+        prior_type, prior_lmbda = prior
+        if prior_type is None:
+            prior_type = "constant"
+        if prior_type.lower() == "gaussian":
+            prior_type = "ridge"
+        elif prior_type.lower() == "laplacian":
+            prior_type = "lasso"
+        self.prior_type = prior_type
+        self.prior_lmbda = prior_lmbda
+
         key =random.PRNGKey(1234)
         word_key, pos_key = random.split(key, 2)
         
-        word_weights = random.normal(word_key, (self.vocab_size, self.embed_dim)) * weight_scale
+        # Fallback initialization: zeros, since scatter-add updates break
+        # symmetry per-token/position without needing random initialization
+        if weight_init is not None:
+            word_weights = weight_init((self.vocab_size, self.embed_dim), word_key)
+        else:
+            word_weights = jnp.zeros((self.vocab_size, self.embed_dim))
         
         if pos_learnable:
-            pos_weights = random.normal(pos_key, (self.seq_len, self.embed_dim)) * weight_scale
+            if weight_init is not None:
+                pos_weights = weight_init((self.seq_len, self.embed_dim), pos_key)
+            else:
+                pos_weights = jnp.zeros((self.seq_len, self.embed_dim))
         else:
             pos_weights = _create_sinusoidal_embeddings(self.seq_len, self.embed_dim)
 
@@ -173,8 +253,13 @@ class EmbeddingSynapse(JaxComponent):
         inputs= inputs.astype(jnp.int32)
         d_word_weights, d_pos_weights = _compute_embedding_updates(
             inputs, post, word_weights, pos_weights, self.vocab_size, self.seq_len,
-            self.embed_dim, batch_size, self.pos_learnable
+            self.embed_dim, batch_size, self.pos_learnable, self.prior_type, self.prior_lmbda
         )
+
+        # Optional soft weight-bound scaling of the update
+        if self.w_bound > 0.:
+            d_word_weights = d_word_weights * (self.w_bound - jnp.abs(word_weights))
+            d_pos_weights = d_pos_weights * (self.w_bound - jnp.abs(pos_weights))
 
         d_word_weights = d_word_weights * self.sign_value
         d_pos_weights = d_pos_weights * self.sign_value
@@ -192,6 +277,11 @@ class EmbeddingSynapse(JaxComponent):
             )
             new_pos_opt_params = pos_opt_params
         
+        # Optional hard clip of weights post-update
+        new_word_weights = _enforce_constraints(new_word_weights, self.w_bound, is_nonnegative=self.is_nonnegative)
+        if self.pos_learnable:
+            new_pos_weights = _enforce_constraints(new_pos_weights, self.w_bound, is_nonnegative=self.is_nonnegative)
+
         # return new_word_weights, new_pos_weights, d_word_weights, d_pos_weights, word_opt_params, new_pos_opt_params
         self.word_weights.set(new_word_weights)
         self.pos_weights.set(new_pos_weights)

--- a/utils/embed_utils.py
+++ b/utils/embed_utils.py
@@ -134,17 +134,15 @@ class EmbeddingSynapse(JaxComponent):
             ("l1l2"/"elastic_net", (scale, l1_ratio))
 
        weight_init: initialization kernel (shape, key) -> array used to
-            initialize word_weights and learnable pos_weights.
-            Default follows initialization strategy as:
-            dist.constant(value=0.0).
-            Random initialization can be supplied if desired.
+                    initialize word_weights and learnable pos_weights.
+                    If None, embeddings are initialized to zeros.
     """
 
     def __init__(
             self, name, vocab_size, seq_len, embed_dim, batch_size,
             pos_learnable, eta, optim_type, weight_scale=0.02, sign_value=-1.,
             w_bound=1., is_nonnegative=False, prior=("constant", 0.),
-            weight_init=dist.constant(value=0.0),
+            weight_init=None,
             **kwargs
     ):
         super().__init__(name, **kwargs)


### PR DESCRIPTION
## Summary

This PR aligns `EmbeddingSynapse` with the weight management behavior used by other learnable synapses (`W_q`, `W_mlp1`, `W_out`, etc.) by adding weight bounding, regularization support, and configurable weight initialization (including fan-in Gaussian initialization) while improving inference stability in `NGCTransformer.process()`.

## Changes

### EmbeddingSynapse improvements

- Added weight bounding for `word_weights` and `pos_weights` with soft scaling near `w_bound` and hard clipping after updates (default `w_bound=1.0`).
  Commit: e321a9a

- Added configurable regularization priors (L1, L2, and Elastic-Net) during updates, disabled by default.
  Commit: e93bbc0

- Updated embedding initialization to support configurable `weight_init`, defaulting to zero initialization when `weight_init=None` while allowing custom initializers such as `dist.fan_in_gaussian()`.
  Commit: 7e27891, 8ddc963, 94692f7

### Fixes

- Fixed `y_mu` UnboundLocalError in `NGCTransformer.process()` by initializing it before the `adapt_synapses` block, ensuring `process()` always returns a valid value when synapses are not adapted (e.g., evaluation).
  Commit: 68f3adc, 21d4040
